### PR TITLE
Mark II Cloudrider

### DIFF
--- a/code/modules/projectiles/ammunition/handfuls.dm
+++ b/code/modules/projectiles/ammunition/handfuls.dm
@@ -84,6 +84,14 @@
 	max_ammo = 1
 	caliber = "14.5mm"
 
+/obj/item/ammo_magazine/handful/modernrifle
+	name = "modern rifle round"
+	desc = "Very modern round that doesn't fit in speedloaders or a hand. Wow."
+	icon = 'icons/obj/ammo.dmi'
+	icon_state = "brifle"
+	ammo_type = /obj/item/ammo_casing/a556
+	max_ammo = 1
+	caliber = "a556"
 
 /*
  * AMMO BOXES
@@ -171,6 +179,13 @@
 	name = "\improper rifle bullets box"
 	desc = "You get rifle bullets out of this one."
 	handful_type = /obj/item/ammo_magazine/handful/brifle_handful
+
+/obj/item/ammo_box/rifle/modern
+	name = "\improper modern rifle bullets box"
+	desc = "You get 556 rifle bullets out of this one."
+	handful_type = /obj/item/ammo_magazine/handful/modernrifle
+	max_stacks = 40
+	handful_verb = "round"
 
 
 //Box of handfuls of shotgun ammo.

--- a/code/modules/projectiles/guns/projectile/mattguns.dm
+++ b/code/modules/projectiles/guns/projectile/mattguns.dm
@@ -42,6 +42,26 @@
 	..()
 	add_bayonet()
 
+//Now THIS is real gun, rare 5 in 100 gun spawn as soldier
+/obj/item/gun/projectile/shotgun/pump/boltaction/good
+	name = "\improper Mark II Cloudrider"
+	desc = "This is the updated and revised version of the Mk. I Stormrider, complete with a new powerful caliber, higher mag capacity, sleek handguard and a straight bolt that makes it hard to shove multiple rounds at a time."
+	icon = 'icons/obj/gun.dmi'
+	condition_icon = 'icons/obj/gun.dmi'
+	icon_state = "mosin2"
+	item_state = "boltaction"
+	wielded_item_state = "boltaction-wielded"
+	condition = 85
+	fire_sound = 'sound/weapons/guns/fire/bar_fire.ogg'
+	max_shells = 8
+	caliber = "a556"
+	ammo_type = /obj/item/ammo_casing/brifle
+	one_hand_penalty = 30 //higher caliber means harder control
+	empty_icon = "karabiner_empty"
+	far_fire_sound = "sniper_fire"
+	gun_type = GUN_BOLTIE //So engineers can't shoot this shit.
+	can_have_bayonet = FALSE
+
 
 /obj/item/gun/projectile/shotgun/pump/boltaction/shitty/leverchester
 	name = "\improper Mark I Snapper"

--- a/maps/coldfare/jobs/blue/blue_soldiers.dm
+++ b/maps/coldfare/jobs/blue/blue_soldiers.dm
@@ -265,6 +265,12 @@
 		backpack_contents = list(/obj/item/grenade/smokebomb = 1)
 		belt = /obj/item/storage/belt/armageddon
 
+	else if (prob(5))
+		suit_store = /obj/item/gun/projectile/shotgun/pump/boltaction/good
+		r_pocket =  /obj/item/ammo_box/rifle/modern
+		backpack_contents = initial(backpack_contents)
+		belt = null
+
 	else if(prob(25))
 		suit_store = /obj/item/gun/projectile/shotgun/pump/boltaction/shitty/leverchester
 		r_pocket = /obj/item/ammo_box/rifle

--- a/maps/coldfare/jobs/red/red_soldiers.dm
+++ b/maps/coldfare/jobs/red/red_soldiers.dm
@@ -268,6 +268,12 @@
 		backpack_contents = list(/obj/item/grenade/smokebomb = 1)
 		belt = /obj/item/storage/belt/armageddon
 
+	else if (prob(5))
+		suit_store = /obj/item/gun/projectile/shotgun/pump/boltaction/good
+		r_pocket =  /obj/item/ammo_box/rifle/modern
+		backpack_contents = initial(backpack_contents)
+		belt = null
+
 	else if(prob(25))
 		suit_store = /obj/item/gun/projectile/shotgun/pump/boltaction/shitty/leverchester
 		r_pocket = /obj/item/ammo_box/rifle


### PR DESCRIPTION
direct successor to the mk i stormrider
has a mag capacity of 8 not including the chamber, making it 9 rounds in the gun
adds an ammo box for it which has 40 rounds of 556
you can only take one round from the box at a time
the gun fires 556
it is bolt action
you cant get the ammo anywhere else than an enemys corpse since the gun is just being rolled out
5 in 100 chance to get the gun on both sides
does not support a bayonet
starts with a superb condition by default
hotline said "idfk" to me proposing itd be 556 so oh well

**has been tested ingame and works correctly**