### PR TITLE
fixes autoshotty mag belts' description

### DIFF
--- a/maps/coldfare/warfare_items.dm
+++ b/maps/coldfare/warfare_items.dm
@@ -785,7 +785,7 @@
 
 /obj/item/storage/belt/autoshotty
 	name = "ammo belt"
-	desc = "Great for holding ammo! This one starts with smg ammo."
+	desc = "Great for holding ammo! This one starts with MS Warcrime magazines."
 	icon_state = "warfare_belt"
 	item_state = "warfare_belt"
 	can_hold = list(


### PR DESCRIPTION
previously it said it had smg ammo in it but in reality it has MS Warcrime mags in it. we have been lied and bamboozled to. speedmerge this now