### PR TITLE
Hud QoL

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -509,6 +509,14 @@ SUBSYSTEM_DEF(jobs)
 	BITSET(H.hud_updateflag, ID_HUD)
 	BITSET(H.hud_updateflag, IMPLOYAL_HUD)
 	BITSET(H.hud_updateflag, SPECIALROLE_HUD)
+	
+	if(iswarfare() && SSwarfare.battle_time && H.warfare_faction)
+	// Reset HUDs for all living players on their team so the hud updates automatically on their spawn
+		for(var/mob/living/carbon/human/team_member in GLOB.living_mob_list_)
+			if(team_member.warfare_faction == H.warfare_faction)
+				team_member.set_squad_huds()
+				team_member.set_team_huds()
+
 	return H
 
 /datum/controller/subsystem/jobs/proc/LoadJobs(jobsfile) //ran during round setup, reads info from jobs.txt -- Urist

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -211,6 +211,12 @@
 		tooltip.alpha = 0
 
 	screen += tooltip
+	
+	if(mob && ishuman(mob)) //I would like my hud icons on reconnect please thank you
+		var/mob/living/carbon/human/H = mob
+		if(H.warfare_faction && SSwarfare && SSwarfare.battle_time)
+			H.set_squad_huds()
+			H.set_team_huds()
 
 /client
 	var/obj/hovered_obj = null

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -367,6 +367,14 @@
 		return 0
 
 	character = SSjobs.EquipRank(character, job.title, 1)					//equips the human
+	
+	if(iswarfare() && SSwarfare.battle_time && character.warfare_faction)
+	// Reset HUDs for all living players on their team so the hud updates automatically on their spawn
+		for(var/mob/living/carbon/human/team_member in GLOB.living_mob_list_)
+			if(team_member.warfare_faction == character.warfare_faction)
+				team_member.set_squad_huds()
+				team_member.set_team_huds()
+	
 	equip_custom_items(character)
 
 	// AIs don't need a spawnpoint, they must spawn at an empty core


### PR DESCRIPTION
- Huds are automatically refreshed for a team when someone spawns in for that team. (I can't really test this on local, but it shouldn't break anything? When you spawn in, the hud icons don't actually show up above you for other players.)
- If you disconnect and reconnect, hud icons are automatically refreshed (as disconnecting would remove them)