### PR TITLE
Removes attachments from vending machines

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1112,18 +1112,14 @@
 	icon_state = "soldiervend"
 	vend_delay = 6
 	vend_ready = 4
-	products = list(/obj/item/reagent_containers/food/snacks/donut/normal = 12, /obj/item/attachable/verticalgrip = 6,
-					/obj/item/attachable/holosight = 6, /obj/item/attachable/reddot = 6, /obj/item/attachable/lasersight = 6,
-					/obj/item/attachable/angledgrip = 6, /obj/item/material/sword/combat_knife = 4, /obj/item/melee/classic_baton/factionbanner/red = 1, /obj/item/storage/box/lights/bulbs = 2) // add weapon bayonets later please
+	products = list(/obj/item/reagent_containers/food/snacks/donut/normal = 12, /obj/item/material/sword/combat_knife = 4, /obj/item/melee/classic_baton/factionbanner/red = 1, /obj/item/storage/box/lights/bulbs = 2) // add weapon bayonets later please/ added :)
 	icon_vend = "soldiervend-vend"
 	icon_deny = "soldiervend-off"
 	rand_amount = FALSE
 
 /obj/machinery/vending/soldier/blue
 	desc = "A Blusnian vending machine powering their war machine."
-	products = list(/obj/item/reagent_containers/food/snacks/donut/normal = 12, /obj/item/attachable/verticalgrip = 6,
-					/obj/item/attachable/holosight = 6, /obj/item/attachable/reddot = 6, /obj/item/attachable/lasersight = 6,
-					/obj/item/attachable/angledgrip = 6, /obj/item/material/sword/combat_knife = 4, /obj/item/melee/classic_baton/factionbanner/blue = 1, /obj/item/storage/box/lights/bulbs = 2) // add weapon bayonets later please
+	products = list(/obj/item/reagent_containers/food/snacks/donut/normal = 12, /obj/item/material/sword/combat_knife = 4, /obj/item/melee/classic_baton/factionbanner/blue = 1, /obj/item/storage/box/lights/bulbs = 2) // add weapon bayonets later please/ added :)
 	icon_state = "soldiervendblue"
 	icon_vend = "soldiervendblue-vend"
 	icon_deny = "soldiervendblue-off"

--- a/maps/coldfare/coldfare.dmm
+++ b/maps/coldfare/coldfare.dmm
@@ -1,1869 +1,40220 @@
-"aa" = (/turf/simulated/mineral{health = 999999},/area/space)
-"ab" = (/turf/simulated/wall/perspecticrete,/area/warfare/homebase/red)
-"ac" = (/obj/structure/stairs/trenchstairs,/obj/structure/announcementspeaker/red{pixel_x = 0; dir = 1},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/two)
-"ad" = (/turf/simulated/floor/stones,/area/warfare/homebase/red/largeroom)
-"ae" = (/obj/structure/bed/chair/throne{pixel_y = -3; buckle_pixel_shift = "x=0;y=-3"},/obj/effect/landmark/start{name = "Red Logistics Lieutenant"},/turf/simulated/floor/stones,/area/warfare/homebase/red/largeroom)
-"af" = (/obj/effect/phone_line,/obj/item/paper_bin{pixel_x = 4; pixel_y = 10},/obj/item/pen/red{pixel_x = 1; pixel_y = 10},/obj/structure/table/nosmooth/capnew{pixel_y = -4; dir = 4},/obj/item/storage/fancy/cigarettes/cigarillo{pixel_x = 6; pixel_y = 3},/obj/structure/table/nosmooth/capnew{pixel_y = 28; dir = 5},/obj/structure/window/reinforced{pixel_x = 0; pixel_y = 7},/turf/simulated/floor/stones,/area/warfare/homebase/red/largeroom)
-"ag" = (/turf/simulated/wall/perspecticrete,/area/warfare/homebase/blue)
-"ah" = (/obj/structure/sign/neon/cargo,/turf/simulated/wall/perspecticrete,/area/warfare/homebase/blue/largeroom)
-"ai" = (/obj/structure/poster/blue,/turf/simulated/wall/perspecticrete,/area/warfare/homebase/blue/largeroom)
-"aj" = (/obj/structure/cargo_pad/blue,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/room)
-"ak" = (/obj/structure/bed/chair/throne{pixel_y = -3; buckle_pixel_shift = "x=0;y=-3"},/obj/effect/landmark/start{name = "Blue Logistics Lieutenant"},/turf/simulated/floor/stones,/area/warfare/homebase/blue/largeroom)
-"al" = (/obj/effect/phone_line,/obj/item/paper_bin{pixel_x = 4; pixel_y = 10},/obj/structure/table/nosmooth/capnew{pixel_y = -4; dir = 4},/obj/item/pen/blue{pixel_x = 2; pixel_y = 10},/obj/item/storage/fancy/cigar{pixel_x = 1; pixel_y = 5},/obj/structure/table/nosmooth/capnew{pixel_y = 28; dir = 5},/obj/structure/window/reinforced{pixel_x = 0; pixel_y = 7},/turf/simulated/floor/stones,/area/warfare/homebase/blue/largeroom)
-"am" = (/obj/structure/trench_wall{dir = 4},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/bunker)
-"an" = (/obj/structure/table/nosmooth/capnew{pixel_y = -4},/obj/item/device/flashlight/lamp/captain/blue{pixel_x = 15; pixel_y = 9},/obj/item/clipboard{pixel_x = -8; pixel_y = 1},/turf/simulated/floor/stones,/area/warfare/homebase/blue/largeroom)
-"ao" = (/obj/structure/closet/secure_closet/warfare/newver,/mob/living/simple_animal/hostile/retaliate/rat,/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/trench_section/underground)
-"ap" = (/obj/structure/window/reinforced{dir = 8; icon_state = "rwindow"},/obj/structure/cargo_pad/red,/obj/sound_emitter/periodic/env_leak,/obj/machinery/light/small/bunker{pixel_x = 0; pixel_y = 32},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/room)
-"aq" = (/turf/simulated/mineral{health = 999999},/area/warfare/homebase/blue)
-"ar" = (/obj/machinery/light/caged{dir = 4; pixel_x = -10; pixel_y = 0},/mob/living/simple_animal/hostile/retaliate/rat,/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/trench_section/underground)
-"as" = (/obj/effect/floor_decal/trench{dir = 1},/mob/living/simple_animal/hostile/retaliate/rat,/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/one)
-"at" = (/obj/effect/floor_decal/trench{dir = 1},/mob/living/simple_animal/hostile/retaliate/rat,/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/two)
-"au" = (/obj/effect/landmark/start{name = "Blue Soldier"},/obj/structure/bed/chair/blue,/obj/machinery/light/small/bunker{dir = 4},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"av" = (/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/stoneroom)
-"aw" = (/obj/effect/landmark/start{name = "Blue Soldier"},/obj/structure/bed/chair/blue{dir = 1; pixel_x = 0; pixel_y = 11; buckle_pixel_shift = "x=0;y=11"},/obj/machinery/light/small/bunker{dir = 4},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"ax" = (/obj/structure/reagent_dispensers/watertank,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"ay" = (/obj/machinery/light/caged{pixel_y = -14; dir = 1; pixel_x = 0},/obj/item/device/compass,/obj/item/device/compass,/obj/structure/table/rack/nosmooth/wood,/turf/simulated/floor/stones,/area/warfare/homebase/blue/room)
-"az" = (/obj/structure/bed/chair/wheelchair,/obj/machinery/light{dir = 1; pixel_y = 32},/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/stoneroom)
-"aB" = (/obj/effect/floor_decal/newcorner/grey,/obj/effect/decal/cleanable/generic,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/hallway)
-"aC" = (/obj/item/storage/fancy/cigarettes/jerichos,/obj/item/flame/lighter/random,/obj/structure/table/rack/nosmooth/wood/alt,/obj/item/flame/candle/blue,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"aD" = (/obj/item/storage/firstaid/regular,/obj/structure/table/rack/nosmooth/wood/alt{dir = 4},/obj/item/flame/candle/blue,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"aE" = (/obj/structure/table/rack/nosmooth/wood/alt{dir = 6},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"aF" = (/obj/item/storage/box/matches,/obj/structure/table/rack/nosmooth/wood/alt{dir = 6},/obj/item/flame/candle/blue,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"aG" = (/obj/item/device/compass,/obj/item/device/compass,/obj/item/device/compass,/obj/structure/table/rack/nosmooth/wood/alt{dir = 4},/obj/item/flame/candle/blue,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"aH" = (/obj/item/storage/fancy/cigarettes,/obj/item/flame/lighter/random,/obj/structure/table/rack/nosmooth/wood/alt{dir = 5},/obj/item/flame/candle/blue,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"aI" = (/obj/structure/table/rack/nosmooth/wood/alt{dir = 4},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"aJ" = (/obj/structure/closet/secure_closet/warfare,/turf/simulated/floor/stones,/area/warfare/homebase/blue/room)
-"aK" = (/obj/item/storage/fancy/cigarettes/carcinomas,/obj/item/ammo_box/rifle,/obj/structure/table/rack/nosmooth/wood/alt{dir = 5},/obj/item/flame/candle/blue,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"aL" = (/obj/structure/reagent_dispensers/watertank/red,/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"aM" = (/obj/item/storage/fancy/cigarettes/carcinomas,/obj/structure/table/rack/nosmooth/wood/alt{dir = 5},/obj/item/flame/candle/blue,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"aN" = (/obj/item/wirecutters,/obj/item/storage/firstaid/regular,/obj/structure/table/rack/nosmooth/wood/alt{dir = 6},/obj/item/flame/candle/blue,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"aP" = (/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/hallway)
-"aR" = (/obj/item/storage/fancy/cigarettes,/obj/item/flame/lighter/random,/obj/machinery/light/caged{pixel_y = -1; dir = 1; pixel_x = 0},/obj/structure/table/rack/nosmooth/metal{dir = 1},/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/room)
-"aS" = (/obj/structure/closet/crate,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"aT" = (/obj/structure/trench_wall,/obj/structure/trench_wall{dir = 1},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/room)
-"aU" = (/obj/structure/destruction_computer/blue,/turf/simulated/floor/tiled,/area/warfare/homebase/blue/largeroom)
-"aV" = (/obj/structure/stairs/west,/obj/machinery/light/small/bunker{pixel_x = 0; pixel_y = 32},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"aW" = (/obj/item/storage/fancy/cigarettes,/obj/item/flame/lighter/zippo,/obj/machinery/light/caged{pixel_y = -1; dir = 1; pixel_x = 0},/obj/structure/announcementspeaker/blue{pixel_y = 0; dir = 8},/obj/structure/table/rack/nosmooth/metal{dir = 4},/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/room)
-"aX" = (/turf/simulated/floor/tiled/ramp{dir = 8; icon_state = "ramptop"},/area/warfare/homebase/blue/stoneroom)
-"aY" = (/obj/machinery/light/small/bunker{pixel_x = 0; pixel_y = 32},/turf/simulated/floor/stones,/area/warfare/homebase/blue/room)
-"aZ" = (/obj/hammereditor/nodraw/deco/shadowpaint,/obj/hammereditor/nodraw/deco/shadowpaint{opacity = 1; dir = 8},/turf/simulated/floor/stones,/area/warfare/homebase/red/trainyard)
-"bb" = (/turf/simulated/wall/perspecticrete,/area/warfare/homebase/blue/div)
-"bc" = (/obj/hammereditor/nodraw/deco/shutter_half,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/room)
-"bd" = (/obj/structure/stairs/trenchstairs{dir = 1},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/two)
-"be" = (/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/stoneroom)
-"bg" = (/obj/structure/poster/red,/turf/simulated/wall/perspecticrete,/area/warfare/homebase/red/largeroom)
-"bh" = (/obj/effect/floor_decal/trench,/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/two)
-"bi" = (/turf/simulated/wall/perspecticrete,/area/warfare/battlefield/trench_section/stoneroom)
-"bk" = (/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/two)
-"bl" = (/obj/structure/bed/chair/blue{dir = 1; pixel_x = 0; pixel_y = 11; buckle_pixel_shift = "x=0;y=11"},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/largeroom)
-"bm" = (/obj/structure/table/nosmooth/capnew{pixel_y = -4},/obj/item/device/flashlight/lamp/captain{pixel_x = 15; pixel_y = 9},/obj/item/clipboard{pixel_x = -8; pixel_y = 2},/turf/simulated/floor/stones,/area/warfare/homebase/red/largeroom)
-"bn" = (/obj/machinery/light/small/bunker{dir = 4},/obj/machinery/button/remote/blast_door/lever{id = "red"; pixel_y = 32},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"bo" = (/obj/structure/trench_wall,/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/blue/one)
-"bq" = (/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/largeroom)
-"br" = (/obj/structure/reagent_dispensers/watertank{pixel_x = 3; pixel_y = 1},/obj/machinery/light/caged{dir = 4; pixel_x = -2; pixel_y = 0},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/room)
-"bs" = (/obj/item/storage/fancy/cigarettes/luckystars,/obj/item/flame/lighter/random,/obj/item/ammo_box/rifle,/obj/structure/table/rack/nosmooth/wood/alt,/obj/item/flame/candle/blue,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"bt" = (/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"bu" = (/obj/structure/closet/crate,/obj/random/canned_food/red,/obj/random/canned_food/red,/obj/random/canned_food/red,/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"bw" = (/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"bx" = (/obj/structure/announcementspeaker/blue{pixel_x = 0; dir = 1},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/hallway)
-"bz" = (/obj/item/storage/box/matches,/obj/structure/table/rack/nosmooth/wood/alt,/obj/item/flame/candle/blue,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"bB" = (/obj/structure/table/rack/nosmooth/wood/alt,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"bC" = (/obj/item/flame/candle,/obj/item/storage/firstaid/regular,/obj/structure/table/rack/nosmooth/wood/alt{dir = 4},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"bD" = (/obj/structure/trench_wall/innercorners{dir = 4},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/bunker)
-"bF" = (/obj/item/flame/candle,/obj/item/device/compass,/obj/item/device/compass,/obj/item/device/compass,/obj/structure/table/rack/nosmooth/wood/alt{dir = 4},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"bG" = (/obj/item/storage/fancy/cigarettes,/obj/item/flame/candle,/obj/item/flame/lighter/random,/obj/structure/table/rack/nosmooth/wood/alt{dir = 4},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"bH" = (/obj/item/flame/candle,/obj/item/storage/firstaid/surgery,/obj/structure/table/rack/nosmooth/wood/alt{dir = 5},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"bJ" = (/obj/item/storage/firstaid/regular,/obj/item/storage/firstaid/regular,/obj/item/storage/firstaid/regular,/obj/item/storage/firstaid/regular,/obj/structure/table/rack/shelf/red,/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/room)
-"bK" = (/obj/structure/table/rack/nosmooth/wood/alt{dir = 5},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"bL" = (/obj/item/flame/candle,/obj/item/storage/fancy/cigarettes/carcinomas,/obj/structure/table/rack/nosmooth/wood/alt{dir = 5},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"bM" = (/obj/item/flame/candle,/obj/item/wirecutters,/obj/item/storage/firstaid/regular,/obj/structure/table/rack/nosmooth/wood/alt{dir = 6},/obj/structure/announcementspeaker/red{pixel_x = 0; dir = 8},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"bN" = (/obj/structure/defensive_barrier{secured = 1; dir = 8; pixel_x = -4; pixel_y = 2},/obj/hammereditor/nodraw,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/room)
-"bO" = (/obj/effect/landmark/start{name = "Red Soldier"},/obj/structure/bed/chair/red{dir = 1; pixel_x = 0; pixel_y = 11; buckle_pixel_shift = "x=0;y=11"},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"bP" = (/obj/effect/floor_decal/trench{dir = 4},/obj/structure/stairs/trenchstairs,/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/two)
-"bR" = (/obj/structure/dirt_wall,/turf/simulated/floor/dirty/tough,/area/warfare/battlefield/capture_point/red/two)
-"bS" = (/obj/structure/destruction_computer/red,/turf/simulated/floor/tiled,/area/warfare/homebase/red/largeroom)
-"bT" = (/obj/item/storage/fancy/cigarettes,/obj/item/flame/lighter/random,/obj/machinery/light/caged{pixel_y = 30; pixel_x = 0},/obj/structure/announcementspeaker/blue{pixel_y = 0; dir = 4},/obj/structure/table/rack/nosmooth/metal{dir = 6},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/room)
-"bU" = (/turf/unsimulated/wall/hammereditor/dev2,/area/warfare/homebase/red/stoneroom)
-"bV" = (/obj/effect/landmark/start{name = "Blue Soldier"},/obj/structure/bed/chair/blue,/obj/machinery/light/small/bunker{dir = 8},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"bW" = (/obj/machinery/light/small/bunker{dir = 1},/turf/simulated/floor/stones,/area/warfare/homebase/red/room)
-"bY" = (/obj/effect/landmark/start{name = "Red Squad Leader"},/turf/simulated/floor/stones,/area/warfare/homebase/red/room)
-"bZ" = (/obj/structure/toilet{dir = 8; icon_state = "toilet00"},/turf/simulated/floor/stones,/area/warfare/homebase/red/room)
-"ca" = (/obj/effect/landmark/start{name = "Red Bartender"},/turf/simulated/floor/stones,/area/warfare/homebase/red/room)
-"cb" = (/obj/effect/landmark/start{name = "Red Soldier"},/turf/simulated/floor/stones,/area/warfare/homebase/red/room)
-"cc" = (/obj/effect/landmark/start{name = "Red Scavenger"},/obj/structure/toilet{dir = 8; icon_state = "toilet00"},/turf/simulated/floor/stones,/area/warfare/homebase/red/room)
-"cd" = (/obj/effect/landmark/start{name = "Red Scavenger"},/turf/simulated/floor/stones,/area/warfare/homebase/red/room)
-"cf" = (/obj/effect/lighting_dummy/daylight,/obj/effect/landmark/train_marker/teleport/red,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/red/trainyard)
-"cg" = (/obj/structure/stairs/trenchstairs,/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/two)
-"ch" = (/obj/machinery/light/caged{pixel_y = -1; dir = 1; pixel_x = 16},/obj/structure/trench_wall{dir = 9; pixel_x = -32; layer = 28},/obj/structure/table/rack/shelf/red,/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"ci" = (/obj/effect/sub_marker/dive{id = "MISSION"},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield)
-"cj" = (/obj/structure/bed,/turf/simulated/floor/stones,/area/warfare/homebase/red/room)
-"cl" = (/obj/structure/closet/secure_closet/warfare,/turf/simulated/floor/stones,/area/warfare/homebase/red/room)
-"cn" = (/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/blue/two)
-"co" = (/turf/simulated/floor/ert/metal01,/area/train/red)
-"cp" = (/obj/structure/announcementspeaker/blue{pixel_x = 0; dir = 1},/turf/simulated/floor/stones,/area/warfare/homebase/blue/largeroom)
-"cq" = (/obj/structure/closet/secure_closet/warfare/newver,/obj/item/crowbar,/obj/item/crowbar,/obj/item/crowbar,/obj/structure/banner/blue/small{pixel_y = 32},/turf/simulated/floor/stones,/area/warfare/homebase/blue/largeroom)
-"cr" = (/obj/structure/closet/secure_closet/warfare,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/room)
-"cs" = (/obj/item/gun/projectile/revolver{name = "Authority"; desc = "Over something as fundemental as life itself"},/obj/machinery/light/small/bunker{pixel_x = 0; pixel_y = 32},/obj/structure/table/rack/nosmooth/wood/alt{dir = 5},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"ct" = (/obj/structure/trench_wall{dir = 6},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/blue/one)
-"cu" = (/obj/structure/announcementspeaker/blue{pixel_y = 0; dir = 4},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/hallway)
-"cw" = (/obj/structure/trench_wall{dir = 4; pixel_x = -32; pixel_y = 0},/obj/structure/announcementspeaker/red{pixel_x = 0; dir = 4},/obj/structure/table/rack/shelf/red,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/room)
-"cx" = (/obj/effect/floor_decal/trench{dir = 4},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/one)
-"cz" = (/obj/effect/floor_decal/trench{dir = 4},/obj/structure/banner/blue/small{pixel_y = 32},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/one)
-"cA" = (/obj/effect/floor_decal/trench{dir = 8},/obj/machinery/light/caged{pixel_y = -1; dir = 1; pixel_x = 0},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/two)
-"cB" = (/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground)
-"cC" = (/obj/structure/soldiercryo/special/blue,/obj/structure/announcementspeaker/red{id = "Bluecoats"; pixel_y = 32},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/stoneroom)
-"cD" = (/obj/effect/phone_line,/obj/item/paper_bin{pixel_x = 4; pixel_y = 10},/obj/item/pen/red{pixel_x = 1; pixel_y = 10},/obj/structure/table/nosmooth/capnew{pixel_y = -4; dir = 4},/obj/item/storage/fancy/cigarettes/cigarillo{pixel_x = 6; pixel_y = 3},/obj/item/flame/lighter/zippo{pixel_x = -2; pixel_y = 2},/turf/simulated/floor/wood,/area/warfare/homebase/red/caproom)
-"cE" = (/obj/machinery/light/caged{pixel_y = 28; pixel_x = 0},/turf/simulated/floor/dirty/indestructable,/area/warfare/homebase/blue)
-"cF" = (/obj/effect/floor_decal/trench{dir = 8},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/one)
-"cG" = (/obj/effect/floor_decal/trench{dir = 10},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/two)
-"cH" = (/obj/structure/closet/secure_closet/medical1/warfare,/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"cJ" = (/obj/machinery/shower{dir = 8; icon_state = "shower"},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"cK" = (/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/blue/one)
-"cL" = (/obj/machinery/light/small/bunker{dir = 8},/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/hallway)
-"cN" = (/obj/structure/table/rack/holorack,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/room)
-"cO" = (/obj/structure/sign/warning/biohazard,/obj/effect/floor_decal/industrial/warning/dust{dir = 4},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/hallway)
-"cP" = (/obj/structure/closet/crate,/obj/random/canned_food/blue,/obj/random/canned_food/blue,/obj/structure/table/rack/holorack,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/room)
-"cR" = (/obj/machinery/light{dir = 1; pixel_y = 32},/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/hallway)
-"cS" = (/obj/structure/toilet{dir = 8; icon_state = "toilet00"},/obj/machinery/light/small/bunker{pixel_x = 0; pixel_y = 32},/turf/simulated/floor/stones,/area/warfare/homebase/red/room)
-"cU" = (/obj/machinery/light/small,/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
-"cV" = (/obj/structure/trench_wall{dir = 4; pixel_x = -32; pixel_y = 0},/obj/structure/table/rack/holorack,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/room)
-"cY" = (/obj/effect/floor_decal/newcorner/grey/diagonal,/obj/effect/floor_decal/newcorner/grey/corner{dir = 4},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/hallway)
-"cZ" = (/obj/structure/table/rack/nosmooth/metal,/obj/item/storage/firstaid/surgery,/obj/machinery/light/small,/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"da" = (/obj/structure/train_deco/sides{dir = 1},/obj/hammereditor/playerclip,/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/stones,/area/warfare/homebase/red/trainyard)
-"db" = (/obj/structure/stairs/trenchstairs{dir = 1},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/one)
-"dd" = (/obj/machinery/door/airlock/multi_tile/metal/maintenance{dir = 1; icon_state = "door_closed"; name = "Emergency Medical"; locked = 1; maxhealth = 5000000},/obj/hammereditor/nodraw,/turf/simulated/wall/perspecticrete,/area/warfare/homebase/blue/hallway)
-"de" = (/obj/structure/banner/blue/small{pixel_y = 32},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/one)
-"df" = (/obj/structure/announcementspeaker/blue{pixel_x = 0; dir = 1},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"dg" = (/obj/structure/stairs/trenchstairs,/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/one)
-"dh" = (/obj/structure/stairs/trenchstairs{dir = 1},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/one)
-"di" = (/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/red/one)
-"dj" = (/obj/structure/trench_wall{dir = 6},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/blue/two)
-"dk" = (/mob/living/simple_animal/hostile/retaliate/rat,/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/one)
-"dl" = (/turf/simulated/wall/perspecticrete,/area/warfare/battlefield/trench_section/room)
-"dn" = (/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"do" = (/obj/machinery/light/caged{pixel_y = 30; pixel_x = 0},/obj/structure/closet/crate/club,/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/room)
-"dp" = (/obj/structure/toilet{dir = 4; icon_state = "toilet00"},/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/room)
-"dr" = (/obj/structure/stairs/trenchstairs,/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/one)
-"ds" = (/obj/structure/announcementspeaker/red{pixel_x = 0; dir = 4},/obj/structure/table/rack/shelf/red,/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/room)
-"dt" = (/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/stoneroom)
-"du" = (/obj/structure/trench_wall,/obj/structure/announcementspeaker/red,/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/indoors)
-"dv" = (/obj/structure/table/rack/holorack,/obj/machinery/light/caged{dir = 1; pixel_y = -1},/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/room)
-"dw" = (/obj/structure/table/woodentable/shelf{pixel_y = 13},/turf/simulated/floor/stones,/area/warfare/homebase/red/largeroom)
-"dx" = (/obj/structure/trench_wall/sequel{dir = 4},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/red/one)
-"dy" = (/obj/item/storage/fancy/cigarettes,/obj/item/flame/lighter/random,/obj/machinery/light/caged{pixel_y = -1; dir = 1; pixel_x = 0},/obj/structure/announcementspeaker/red{pixel_x = 0; dir = 4},/obj/structure/table/rack/nosmooth/metal{dir = 1},/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/room)
-"dz" = (/obj/item/storage/fancy/cigarettes,/obj/item/flame/lighter/zippo,/obj/machinery/light/caged{pixel_y = -1; dir = 1; pixel_x = 0},/obj/structure/table/rack/nosmooth/metal{dir = 4},/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/room)
-"dA" = (/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/red/two)
-"dC" = (/obj/structure/trench_wall{dir = 8; pixel_x = 32; pixel_y = 0},/obj/structure/trench_wall/innercorners{dir = 8; pixel_x = 32; pixel_y = -32},/obj/structure/trench_wall{dir = 8; pixel_x = 32; pixel_y = 0},/obj/structure/trench_wall/sequel{dir = 6; pixel_x = 0; pixel_y = -32},/obj/structure/closet/crate/grenade,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/room)
-"dD" = (/turf/simulated/wall/perspecticrete,/area/warfare/battlefield/trench_section/hallway)
-"dF" = (/obj/machinery/light/caged{pixel_y = 30; pixel_x = 0},/obj/structure/trench_wall{dir = 8; pixel_x = 32; pixel_y = 0},/obj/structure/table/rack/shelf/red,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/room)
-"dG" = (/obj/hammereditor/nodraw,/turf/simulated/wall/perspecticrete,/area/warfare/homebase/red/room)
-"dH" = (/obj/structure/trench_wall/sequel{dir = 4},/obj/structure/trench_wall{dir = 4},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/indoors)
-"dJ" = (/obj/item/storage/fancy/cigarettes,/obj/item/flame/lighter/random,/obj/machinery/light/caged{pixel_y = 30; pixel_x = 0},/obj/structure/announcementspeaker/red{pixel_x = 0; dir = 4},/obj/structure/table/rack/nosmooth/metal{dir = 6},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/room)
-"dK" = (/obj/item/storage/fancy/cigarettes,/obj/item/flame/lighter/zippo,/obj/machinery/light/caged{pixel_y = 30; pixel_x = 0},/obj/structure/table/rack/nosmooth/metal{dir = 8},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/room)
-"dL" = (/obj/structure/table/rack,/obj/structure/announcementspeaker/red{id = "Bluecoats"; pixel_y = 32},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/stoneroom)
-"dM" = (/obj/effect/floor_decal/newcorner/grey/corner{dir = 4},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/hallway)
-"dN" = (/obj/effect/floor_decal/industrial/warning/dust{dir = 1},/obj/effect/darkout_teleporter/bluecoats,/obj/effect/floor_decal/train_deco/stripes,/obj/effect/lighting_dummy/daylight,/obj/effect/landmark/train_marker/teleport/blue,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/blue/trainyard)
-"dO" = (/obj/structure/trench_wall{dir = 8; pixel_x = 32; pixel_y = 0},/obj/structure/table/rack/holorack,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/room)
-"dP" = (/obj/structure/trench_wall{dir = 10},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/red/two)
-"dQ" = (/obj/structure/toilet{dir = 4; icon_state = "toilet00"},/obj/structure/trench_wall{dir = 4; pixel_x = -32; pixel_y = 0},/obj/structure/trench_wall/innercorners{dir = 4; pixel_x = -32; pixel_y = -32},/obj/structure/trench_wall/sequel{dir = 5; pixel_x = 0; pixel_y = -32},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/room)
-"dR" = (/obj/structure/closet/crate/wooden{pixel_x = -10; pixel_y = 42},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/blue/trainyard)
-"dS" = (/obj/structure/stairs/trenchstairs{dir = 1},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/two)
-"dT" = (/obj/machinery/door/airlock/multi_tile/metal/maintenance/red,/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/room)
-"dU" = (/obj/structure/railing/urban{dir = 4},/obj/effect/floor_decal/industrial/warning/dust/corner,/obj/effect/floor_decal/industrial/warning/dust/corner{dir = 8},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/red/trainyard)
-"dV" = (/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/concrete/random,/area/warfare/battlefield/capture_point/blue/one)
-"dW" = (/obj/structure/banner/red/small{pixel_y = 32},/obj/effect/floor_decal/trench{dir = 6},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/two)
-"dX" = (/obj/structure/stairs/trenchstairs,/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/two)
-"dZ" = (/obj/structure/stairs/west,/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/hallway)
-"ea" = (/obj/effect/landmark{name = "tdome1"},/turf/simulated/mineral{health = 999999},/area/space)
-"eb" = (/turf/unsimulated/wall/submarine/doors{dir = 4},/area/warfare/homebase/red/room)
-"ec" = (/obj/machinery/camera{dir = 4; pixel_x = 2; pixel_y = 0},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/red/trainyard)
-"ed" = (/obj/structure/closet/crate/wooden{pixel_x = -3; pixel_y = 1},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/red/trainyard)
-"ee" = (/turf/space,/area/warfare/homebase/red/trainyard)
-"ef" = (/obj/effect/floor_decal/trench,/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/one)
-"eg" = (/obj/machinery/camera{dir = 4; pixel_x = 2; pixel_y = 0},/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/room)
-"eh" = (/obj/structure/table/rack/nosmooth/metal,/obj/item/reagent_containers/spray/cleaner/warfare{pixel_x = -4; pixel_y = 0},/obj/item/reagent_containers/spray/cleaner/warfare{pixel_x = -12; pixel_y = 4},/obj/item/reagent_containers/spray/cleaner/warfare{pixel_x = 4; pixel_y = 0},/obj/item/reagent_containers/spray/cleaner/warfare{pixel_x = 12; pixel_y = 4},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/stoneroom)
-"ei" = (/obj/effect/sub_marker/surface{id = "SUB_END"},/turf/simulated/mineral{health = 999999},/area/warfare/homebase/red)
-"ej" = (/obj/machinery/light{dir = 8},/obj/structure/announcementspeaker/red{pixel_x = 0; dir = 4},/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/hallway)
-"ek" = (/obj/effect/landmark/start{name = "Blue Soldier"},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"el" = (/obj/structure/bed/chair/wheelchair,/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/stoneroom)
-"em" = (/obj/structure/trench_wall{dir = 8; pixel_x = 32},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/space)
-"en" = (/obj/structure/railing/urban{dir = 4},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/blue/trainyard)
-"eo" = (/obj/effect/sub_marker/dive{id = "SUB_END"},/turf/simulated/mineral{health = 999999},/area/warfare/homebase/red)
-"ep" = (/obj/machinery/light/small/bunker{dir = 4},/obj/structure/soldiercryo/special/blue,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/stoneroom)
-"er" = (/obj/structure/toilet{dir = 4; icon_state = "toilet00"},/obj/machinery/light/small/bunker{dir = 8},/turf/simulated/floor/stones,/area/warfare/homebase/blue/room)
-"et" = (/obj/machinery/vending/medical{req_access = newlist()},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"eu" = (/obj/machinery/door/airlock/multi_tile/metal/maintenance{dir = 1; icon_state = "door_closed"; name = "Emergency Medical"},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/stoneroom)
-"ev" = (/obj/hammereditor/nodraw/deco/bars{dir = 8},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/hallway)
-"ew" = (/obj/machinery/door/airlock/bunker/red,/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/hallway)
-"ex" = (/obj/structure/table/rack/holorack,/obj/machinery/light/small/bunker{dir = 1},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"ey" = (/obj/machinery/body_scanconsole{dir = 4; icon_state = "body_scannerconsole"},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"ez" = (/turf/unsimulated/wall/hammereditor/dev1,/area/warfare/homebase/blue)
-"eA" = (/obj/structure/trench_wall{dir = 8},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/indoors)
-"eB" = (/obj/effect/darkout_teleporter/bluecoats,/obj/effect/floor_decal/industrial/warning/dust,/obj/effect/landmark/train_marker/teleport/red,/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/red/trainyard)
-"eD" = (/obj/machinery/light{dir = 8},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/hallway)
-"eF" = (/obj/hammereditor/nodraw/deco/bars{dir = 4},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/hallway)
-"eG" = (/obj/effect/decal/cleanable/blood,/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
-"eI" = (/obj/structure/stairs/west{dir = 4},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/hallway)
-"eJ" = (/turf/simulated/floor/tiled/ramp{dir = 4; icon_state = "ramptop"},/area/warfare/homebase/blue/hallway)
-"eK" = (/turf/simulated/open,/area/warfare/homebase/blue/hallway)
-"eL" = (/obj/effect/floor_decal/newcorner/grey/corner,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/hallway)
-"eN" = (/obj/machinery/door/airlock/multi_tile/metal/maintenance/blue,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/hallway)
-"eO" = (/obj/structure/trench_wall{dir = 8},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/room)
-"eP" = (/obj/structure/poster/blue{pixel_y = 32},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"eR" = (/obj/structure/trench_wall{dir = 10},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/red/one)
-"eS" = (/obj/structure/trench_wall{dir = 8},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/blue/one)
-"eW" = (/obj/item/device/compass,/obj/structure/table/rack/nosmooth/wood/alt,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"eX" = (/obj/structure/trench_wall{dir = 8; pixel_x = 32; pixel_y = 0},/obj/structure/table/rack/holorack,/obj/machinery/light/caged{pixel_y = 30; pixel_x = 0},/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/room)
-"eY" = (/obj/structure/announcementspeaker/red{pixel_x = 0; dir = 4},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"fa" = (/obj/effect/landmark/start{name = "Blue Soldier"},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/largeroom)
-"fb" = (/obj/effect/landmark/start{name = "Blue Scavenger"},/obj/structure/toilet{dir = 8; icon_state = "toilet00"},/turf/simulated/floor/stones,/area/warfare/homebase/blue/room)
-"fc" = (/obj/effect/landmark/start{name = "Blue Soldier"},/obj/structure/toilet{dir = 8; icon_state = "toilet00"},/turf/simulated/floor/stones,/area/warfare/homebase/blue/room)
-"fe" = (/obj/structure/poster/blue,/turf/simulated/wall/perspecticrete,/area/warfare/homebase/blue/room)
-"fi" = (/obj/effect/landmark/start{name = "Blue Soldier"},/obj/structure/bed/chair/blue{dir = 4},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"fj" = (/obj/structure/table/rack/nosmooth/wood/alt{dir = 6},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"fk" = (/obj/effect/landmark/start{name = "Blue Soldier"},/obj/machinery/light/small/bunker{dir = 4},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"fo" = (/obj/structure/table/rack/nosmooth/wood/alt{dir = 5},/obj/item/storage/box/matches{pixel_x = 7; pixel_y = 10},/obj/item/flame/lighter/random{pixel_x = -4; pixel_y = 5},/obj/item/wirecutters{pixel_x = 17; pixel_y = 1},/obj/item/storage/fancy/cigarettes/carcinomas{pixel_x = -11; pixel_y = 14},/obj/item/storage/fancy/cigarettes{pixel_x = 18; pixel_y = 13},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"fp" = (/obj/item/storage/firstaid/toxin,/obj/item/storage/firstaid/toxin,/obj/item/storage/firstaid/toxin,/obj/item/storage/firstaid/toxin,/obj/structure/table/rack/shelf/red,/obj/structure/announcementspeaker/red{pixel_x = 0; dir = 4},/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/room)
-"fq" = (/obj/machinery/door/airlock/multi_tile/metal/maintenance{dir = 1; icon_state = "door_closed"; name = "Emergency Medical"},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"fr" = (/obj/effect/landmark/start{name = "Blue Soldier"},/obj/structure/bed/chair/blue{dir = 1; pixel_x = 0; pixel_y = 11; buckle_pixel_shift = "x=0;y=11"},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"ft" = (/obj/effect/landmark/start{name = "Blue Engineer"},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"fv" = (/obj/structure/curtain/medical{color = "#b8dddddd"},/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/stoneroom)
-"fw" = (/obj/effect/landmark/start{name = "Blue Squad Leader"},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"fx" = (/obj/item/device/compass,/obj/item/device/compass,/obj/item/device/compass,/obj/item/device/compass,/obj/item/device/compass,/obj/structure/table/rack/nosmooth/wood/alt{dir = 4},/obj/item/flame/candle/blue,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"fy" = (/obj/item/storage/fancy/cigarettes/carcinomas,/obj/item/device/cassette/tape3,/obj/structure/table/rack/nosmooth/wood{dir = 6},/obj/machinery/light/small/bunker{pixel_x = 0; pixel_y = 32},/obj/item/flame/candle/blue,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"fz" = (/obj/structure/safe/floor,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/hallway)
-"fA" = (/obj/item/storage/box/matches,/obj/item/device/cassette/tape1,/obj/item/device/cassette/tape2,/obj/structure/table/rack/nosmooth/wood{dir = 10},/obj/item/flame/candle/blue,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"fB" = (/obj/effect/landmark/start{name = "Blue Sniper"},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"fC" = (/obj/effect/landmark/start{name = "Blue Sentry"},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"fD" = (/obj/structure/barbwire,/turf/simulated/floor/dirty/indestructable,/area/warfare/battlefield/capture_point/blue/one)
-"fE" = (/obj/structure/closet/crate{name = "gasmask crate"},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"fG" = (/obj/machinery/button/remote/blast_door/lever{id = "blue"; pixel_x = -1; pixel_y = -32},/obj/structure/announcementspeaker/blue{pixel_x = 0; dir = 1},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"fH" = (/obj/item/storage/fancy/cigarettes/jerichos,/obj/item/flame/lighter/random,/obj/item/device/boombox,/obj/structure/table/rack/nosmooth/wood{dir = 5},/obj/machinery/light/small/bunker{dir = 1},/obj/item/flame/candle/blue,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"fI" = (/obj/machinery/button/remote/blast_door/lever{id = "blue"; pixel_x = -32},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/hallway)
-"fJ" = (/obj/effect/landmark/start{name = "Blue Soldier"},/obj/machinery/button/remote/blast_door/lever{id = "blue"; pixel_x = 0; pixel_y = -32},/obj/structure/announcementspeaker/blue{pixel_x = 0; dir = 1},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"fK" = (/obj/effect/landmark/start{name = "Blue Flame Trooper"},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"fL" = (/obj/effect/landmark/start{name = "Red Soldier"},/obj/structure/bed/chair/red,/obj/machinery/light/caged{pixel_y = 30; pixel_x = -16},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"fM" = (/obj/structure/barbwire,/turf/simulated/floor/dirty/indestructable,/area/warfare/battlefield/capture_point/blue/two)
-"fN" = (/obj/structure/dirt_wall,/obj/machinery/door/blast/shutters/open{id = "blue"},/turf/simulated/floor/dirty/indestructable,/area/warfare/homebase/blue/largeroom)
-"fO" = (/obj/machinery/door/blast/shutters/open{id = "blue"},/obj/machinery/door/airlock/multi_tile/metal/maintenance/blue,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/hallway)
-"fP" = (/obj/machinery/door/blast/shutters/open{id = "blue"},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/hallway)
-"fQ" = (/obj/structure/closet/crate/trashcart,/turf/simulated/floor/trenches,/area/warfare/homebase/blue)
-"fR" = (/turf/simulated/floor/dirty/indestructable,/area/warfare/homebase/blue)
-"fS" = (/obj/structure/banner/blue{pixel_y = 32},/turf/simulated/floor/dirty/indestructable,/area/warfare/homebase/blue)
-"fT" = (/obj/structure/banner/blue{pixel_x = 0; pixel_y = 32},/turf/simulated/floor/dirty/indestructable,/area/warfare/homebase/blue)
-"fU" = (/obj/structure/poster/blue,/obj/hammereditor/nodraw,/turf/simulated/wall/perspecticrete,/area/warfare/homebase/blue/room)
-"fV" = (/obj/structure/closet/crate{name = "gasmask crate"},/obj/item/clothing/mask/gas/blue,/obj/item/clothing/mask/gas/blue,/obj/item/clothing/mask/gas/blue,/obj/item/clothing/mask/gas/blue,/obj/item/clothing/mask/gas/blue,/obj/item/clothing/mask/gas/blue,/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue)
-"fW" = (/obj/structure/dirt_wall,/turf/simulated/floor/dirty/indestructable,/area/warfare/homebase/blue)
-"fX" = (/obj/structure/barbwire,/turf/simulated/floor/dirty/indestructable,/area/warfare/homebase/blue)
-"fY" = (/turf/simulated/floor/dirty/tough,/area/warfare/homebase/blue)
-"fZ" = (/obj/structure/closet/crate,/obj/item/crowbar,/obj/item/crowbar,/obj/item/crowbar,/obj/item/plastique/blue,/obj/item/plastique/blue,/obj/item/plastique/blue,/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue)
-"gb" = (/turf/simulated/floor/dirty/tough,/area/warfare/battlefield/capture_point/blue/two)
-"gc" = (/obj/structure/dirt_wall,/turf/simulated/floor/dirty/indestructable,/area/warfare/battlefield/capture_point/blue/two)
-"gd" = (/turf/simulated/floor/trench,/area/warfare/battlefield/capture_point/blue/two)
-"ge" = (/turf/simulated/open,/area/warfare/battlefield/capture_point/blue/two)
-"gf" = (/obj/effect/floor_decal/newcorner/grey/corner,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/hallway)
-"gg" = (/obj/hammereditor/nodraw,/turf/simulated/wall/perspecticrete,/area/warfare/homebase/blue/room)
-"gh" = (/obj/effect/floor_decal/industrial/warning/dust{dir = 1},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/hallway)
-"gi" = (/turf/simulated/floor/dirty/indestructable,/area/warfare/battlefield/capture_point/blue/two)
-"gj" = (/turf/simulated/floor/dirty/indestructable,/area/warfare/battlefield/trench_section)
-"gk" = (/obj/structure/dirt_wall,/turf/simulated/floor/dirty/indestructable,/area/warfare/battlefield/trench_section)
-"gl" = (/obj/structure/barbwire,/turf/simulated/floor/dirty/indestructable,/area/warfare/battlefield/trench_section)
-"gm" = (/turf/simulated/open,/area/warfare/battlefield/capture_point/blue/one)
-"gn" = (/turf/simulated/floor/dirty/indestructable,/area/warfare/battlefield/capture_point/blue/one)
-"go" = (/obj/structure/dirt_wall,/turf/simulated/floor/dirty/indestructable,/area/warfare/battlefield/capture_point/blue/one)
-"gp" = (/turf/simulated/floor/trench,/area/warfare/battlefield/capture_point/blue/one)
-"gq" = (/turf/simulated/floor/dirty/fake,/area/warfare/battlefield/capture_point/blue/one)
-"gr" = (/obj/structure/barbwire,/turf/simulated/floor/dirty/fake,/area/warfare/battlefield/capture_point/blue/one)
-"gv" = (/obj/machinery/light/caged{dir = 8; pixel_x = 10; pixel_y = 0},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/trench_section/underground)
-"gw" = (/obj/item/storage/toolbox/mechanical{pixel_x = 14; pixel_y = 8},/obj/item/crowbar/prybar{pixel_x = 3; pixel_y = 13},/obj/item/screwdriver{pixel_x = 8},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/room)
-"gx" = (/turf/simulated/floor,/area/warfare/battlefield/no_mans_land)
-"gA" = (/obj/structure/barbwire,/turf/simulated/floor/dirty/fake,/area/warfare/battlefield/capture_point/red/one)
-"gB" = (/turf/simulated/floor/dirty/fake,/area/warfare/battlefield/capture_point/red/one)
-"gC" = (/obj/structure/dirt_wall,/turf/simulated/floor/dirty/indestructable,/area/warfare/battlefield/capture_point/red/one)
-"gD" = (/turf/simulated/floor/trench,/area/warfare/battlefield/capture_point/red/one)
-"gE" = (/turf/simulated/open,/area/warfare/battlefield/capture_point/red/one)
-"gF" = (/obj/item/storage/belt/medical/full,/obj/item/storage/belt/medical/full,/obj/item/storage/belt/medical/full,/obj/item/storage/belt/medical/full,/obj/item/storage/belt/medical/full,/obj/machinery/light/caged{pixel_y = 30; pixel_x = 0},/obj/structure/trench_wall/innercorners{dir = 1; pixel_x = 32; pixel_y = 31},/obj/structure/trench_wall{dir = 5; pixel_x = 32; layer = 28},/obj/structure/table/rack/shelf/red,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"gG" = (/turf/simulated/open,/area/warfare/battlefield/capture_point/red/two)
-"gH" = (/obj/structure/cargo_pad/blue,/obj/structure/window/reinforced{dir = 4; icon_state = "rwindow"},/obj/machinery/light/small/bunker{pixel_x = 0; pixel_y = 32},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/room)
-"gI" = (/obj/structure/trench_wall{dir = 5; pixel_x = 32; layer = 28},/obj/structure/trench_wall/innercorners{dir = 1; pixel_x = 32; pixel_y = 31},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"gJ" = (/obj/structure/dirt_wall,/turf/simulated/floor/dirty/indestructable,/area/warfare/battlefield/capture_point/red/two)
-"gL" = (/turf/simulated/floor/trench,/area/warfare/battlefield/capture_point/red/two)
-"gM" = (/turf/simulated/floor/dirty/tough,/area/warfare/battlefield/capture_point/red/two)
-"gN" = (/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red)
-"gO" = (/turf/simulated/floor/dirty/tough,/area/warfare/homebase/red)
-"gP" = (/obj/structure/closet/crate,/obj/item/crowbar,/obj/item/crowbar,/obj/item/crowbar,/obj/item/plastique/red,/obj/item/plastique/red,/obj/item/plastique/red,/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red)
-"gQ" = (/obj/structure/barbwire,/turf/simulated/floor/dirty/indestructable,/area/warfare/homebase/red)
-"gR" = (/turf/simulated/floor/dirty/indestructable,/area/warfare/homebase/red)
-"gS" = (/obj/structure/dirt_wall,/turf/simulated/floor/dirty/indestructable,/area/warfare/homebase/red)
-"gT" = (/obj/structure/closet/crate/trashcart,/turf/simulated/floor/trenches,/area/warfare/homebase/red)
-"gW" = (/obj/structure/banner/red{pixel_y = -32; pixel_z = 0},/turf/simulated/floor/dirty/indestructable,/area/warfare/homebase/red)
-"gX" = (/obj/structure/banner/red{pixel_y = -32},/turf/simulated/floor/dirty/indestructable,/area/warfare/homebase/red)
-"gY" = (/obj/structure/dirt_wall,/obj/machinery/door/blast/shutters/open{id = "red"},/turf/simulated/floor/dirty/indestructable,/area/warfare/homebase/red/largeroom)
-"gZ" = (/obj/machinery/door/blast/shutters/open{id = "red"},/obj/machinery/door/airlock/multi_tile/metal/maintenance/red,/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/hallway)
-"ha" = (/obj/machinery/door/blast/shutters/open{id = "red"},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/hallway)
-"hc" = (/obj/structure/train_deco/tracks01,/turf/simulated/floor/urban/destroyed,/area/warfare/homebase/blue/trainyard)
-"hd" = (/obj/effect/floor_decal/industrial/warning/dust{dir = 8},/obj/effect/floor_decal/industrial/warning/dust,/obj/effect/lighting_dummy/daylight,/obj/effect/landmark/train_marker/teleport/red,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/red/trainyard)
-"he" = (/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/space)
-"hf" = (/obj/hammereditor/nodraw/deco/shadowpaint{opacity = 1; dir = 8},/obj/hammereditor/nodraw/deco/shadowpaint{opacity = 1; dir = 1},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/stones,/area/warfare/homebase/blue/trainyard)
-"hg" = (/obj/item/storage/fancy/cigarettes,/obj/item/flame/candle,/obj/item/flame/lighter/random,/obj/structure/table/rack/nosmooth/wood/alt{dir = 5},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"hh" = (/obj/structure/trench_wall{dir = 5; layer = 28},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/indoors)
-"hi" = (/obj/effect/landmark/start{name = "Blue Soldier"},/obj/structure/bed/chair/blue,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"hj" = (/obj/machinery/door/airlock/multi_tile/metal/maintenance/blue,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/stoneroom)
-"hk" = (/obj/structure/closet/crate/wooden/large{icon_closed = "meatball"; icon_state = "meatball"; pixel_x = -2; pixel_y = -2},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/blue/trainyard)
-"hl" = (/obj/machinery/button/remote/blast_door/lever{id = "red"; pixel_x = -32},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/hallway)
-"hn" = (/obj/effect/landmark/start{name = "Red Soldier"},/obj/machinery/button/remote/blast_door/lever{id = "red"; pixel_y = 32},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"ho" = (/obj/effect/landmark/start{name = "Red Engineer"},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"hp" = (/obj/effect/landmark/start{name = "Red Sniper"},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"hq" = (/obj/effect/floor_decal/trench{dir = 4},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/two)
-"ht" = (/obj/effect/landmark/start{name = "Red Flame Trooper"},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"hv" = (/obj/effect/decal/cleanable/blood,/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"hw" = (/obj/effect/floor_decal/trench{dir = 10},/obj/machinery/light/caged{pixel_y = -1; dir = 1; pixel_x = 0},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/one)
-"hx" = (/obj/effect/landmark/start{name = "Red Sentry"},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"hy" = (/obj/effect/landmark/start{name = "Red Soldier"},/obj/structure/bed/chair/red{dir = 4; pixel_x = 6; pixel_y = 0; buckle_pixel_shift = "x=6;y=0"},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"hz" = (/obj/structure/table/rack/nosmooth/wood/alt{dir = 8},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"hA" = (/obj/effect/landmark/start{name = "Red Soldier"},/obj/structure/bed/chair/red{dir = 8; pixel_x = -6; pixel_y = 0; buckle_pixel_shift = "x=-6;y=0"},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"hB" = (/obj/structure/trench_wall/sequel{dir = 4},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground)
-"hC" = (/obj/item/flame/candle,/obj/item/device/compass,/obj/item/device/compass,/obj/item/device/compass,/obj/item/device/compass,/obj/item/device/compass,/obj/structure/table/rack/nosmooth/wood/alt{dir = 4},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"hH" = (/obj/effect/floor_decal/urban/trim1,/obj/effect/floor_decal/urban/trim1{dir = 1},/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"hI" = (/obj/effect/floor_decal/trench{dir = 10},/obj/structure/stairs/trenchstairs,/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/one)
-"hJ" = (/obj/machinery/door/airlock/multi_tile/metal/maintenance{dir = 1; icon_state = "door_closed"; name = "Emergency Medical"},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/stoneroom)
-"hL" = (/obj/structure/closet/crate/medical,/obj/item/wirecutters,/obj/item/wirecutters,/obj/item/storage/firstaid/regular,/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"hM" = (/obj/structure/closet/crate/medical,/obj/item/wirecutters,/obj/item/storage/firstaid/regular,/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"hN" = (/obj/machinery/door/airlock/multi_tile/metal/maintenance/red,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/room)
-"hO" = (/obj/hammereditor/nodraw,/turf/simulated/wall/perspecticrete,/area/warfare/homebase/blue/hallway)
-"hP" = (/obj/machinery/light,/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/stoneroom)
-"hQ" = (/obj/item/device/compass,/obj/structure/table/rack/nosmooth/wood/alt{dir = 6},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"hR" = (/obj/item/flame/candle,/obj/item/storage/fancy/cigarettes/carcinomas,/obj/item/device/cassette/tape3,/obj/structure/table/rack/nosmooth/wood{dir = 6},/obj/machinery/light/small/bunker{pixel_x = 0; pixel_y = 32},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"hS" = (/obj/item/flame/candle,/obj/item/storage/box/matches,/obj/item/device/cassette/tape1,/obj/item/device/cassette/tape2,/obj/structure/table/rack/nosmooth/wood{dir = 10},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"hU" = (/obj/machinery/shower{dir = 8; icon_state = "shower"},/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/room)
-"hV" = (/obj/effect/landmark/start{name = "Red Bartender"},/obj/structure/toilet{dir = 4; icon_state = "toilet00"},/turf/simulated/floor/stones,/area/warfare/homebase/red/room)
-"hW" = (/obj/item/storage/fancy/cigarettes/jerichos,/obj/item/flame/candle,/obj/item/flame/lighter/random,/obj/item/device/boombox,/obj/structure/table/rack/nosmooth/wood{dir = 5},/obj/machinery/light/small/bunker{dir = 1},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"hZ" = (/obj/structure/defensive_barrier{secured = 1; dir = 4; pixel_x = 2; pixel_y = 1},/obj/hammereditor/nodraw,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/hallway)
-"ia" = (/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/stones,/area/warfare/homebase/red/trainyard)
-"ib" = (/obj/effect/darkout_teleporter/bluecoats,/obj/effect/floor_decal/train_deco/stripes{pixel_y = 11},/obj/effect/floor_decal/industrial/warning/dust,/obj/effect/landmark/train_marker/teleport/red,/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/red/trainyard)
-"ic" = (/obj/structure/bed/chair/wheelchair,/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/stoneroom)
-"id" = (/turf/simulated/floor/tiled/ramp{dir = 4; icon_state = "ramptop"},/area/warfare/homebase/red/hallway)
-"ie" = (/turf/simulated/open,/area/warfare/homebase/red/hallway)
-"if" = (/obj/effect/landmark/start{name = "Red Practitioner"},/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/stoneroom)
-"ig" = (/obj/effect/lighting_dummy/daylight,/obj/effect/landmark{name = "Observer-Start"},/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section)
-"ih" = (/obj/structure/table/rack/nosmooth/metal,/obj/structure/curtain,/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/stoneroom)
-"ii" = (/turf/simulated/floor/tiled/ramp{dir = 8; icon_state = "ramptop"},/area/warfare/homebase/red/stoneroom)
-"ij" = (/obj/structure/table/rack/nosmooth/metal,/obj/item/storage/firstaid/surgery,/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/room)
-"ik" = (/obj/structure/trench_wall/sequel{dir = 4},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/blue/two)
-"il" = (/obj/effect/floor_decal/industrial/warning/dust/corner,/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/red/trainyard)
-"im" = (/obj/effect/landmark{name = "JoinLate"},/turf/simulated/mineral{health = 999999},/area/warfare/homebase/red)
-"in" = (/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/red/trainyard)
-"io" = (/obj/structure/bed/roller,/obj/structure/curtain,/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/stoneroom)
-"ip" = (/obj/structure/curtain/medical{color = "#b8dddddd"},/obj/structure/bed/roller,/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/stoneroom)
-"iq" = (/obj/effect/landmark/test/space_turf,/turf/simulated/mineral{health = 999999},/area/warfare/homebase/red)
-"ir" = (/obj/structure/train_deco/tracks01,/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/stones,/area/warfare/homebase/red/trainyard)
-"it" = (/obj/effect/decal/cleanable/blood,/obj/structure/announcementspeaker/red{pixel_x = 0; dir = 4},/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/room)
-"iu" = (/obj/machinery/body_scanconsole{dir = 4; icon_state = "body_scannerconsole"},/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/room)
-"iv" = (/obj/machinery/bodyscanner{dir = 4; icon_state = "body_scanner_0"},/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/room)
-"ix" = (/obj/hammereditor/nodraw/deco/shadowpaint{opacity = 1; dir = 8},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/stones,/area/warfare/homebase/red/trainyard)
-"iy" = (/obj/structure/stairs/west{dir = 4},/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/stoneroom)
-"iA" = (/turf/simulated/open,/area/warfare/homebase/red/stoneroom)
-"iB" = (/obj/machinery/light,/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/stoneroom)
-"iD" = (/obj/machinery/light/small{dir = 1; pixel_y = 32},/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/room)
-"iE" = (/obj/effect/landmark/map_data{height = 2},/turf/simulated/mineral{health = 999999},/area/warfare/homebase/red)
-"iK" = (/obj/item/storage/toggle/envelope{pixel_x = 0; pixel_y = 5},/obj/item/storage/toggle/envelope{pixel_x = -8; pixel_y = 5},/obj/item/storage/toggle/envelope{pixel_x = 8; pixel_y = 5},/obj/item/storage/toggle/envelope{pixel_x = -8; pixel_y = 3},/obj/item/storage/toggle/envelope{pixel_x = 0; pixel_y = 3},/obj/item/storage/toggle/envelope{pixel_x = 8; pixel_y = 3},/obj/item/storage/toggle/envelope{pixel_x = -8; pixel_y = 1},/obj/item/storage/toggle/envelope{pixel_x = 0; pixel_y = 1},/obj/item/storage/toggle/envelope{pixel_x = 8; pixel_y = 1},/obj/structure/table/nosmooth/capnew{pixel_y = -4; dir = 8},/obj/structure/table/nosmooth/capnew{pixel_y = 28; dir = 9; pixel_x = 0},/obj/item/storage/box/matches{pixel_x = 0; pixel_y = 17},/obj/structure/window/reinforced{pixel_x = 0; pixel_y = 7},/obj/item/flame/candle/blue{pixel_x = -11; pixel_y = 20},/obj/item/flame/candle/blue{pixel_x = -9; pixel_y = 20},/obj/item/flame/candle/blue{pixel_x = -7; pixel_y = 20},/obj/item/waxstamp/blue{pixel_x = -10; pixel_y = 16},/obj/machinery/light{dir = 8},/turf/simulated/floor/stones,/area/warfare/homebase/blue/largeroom)
-"iQ" = (/obj/structure/closet/crate,/obj/machinery/light/small/bunker{pixel_x = 0; pixel_y = 32},/obj/random/canned_food/red,/obj/random/canned_food/red,/obj/structure/announcementspeaker/red{id = "Bluecoats"; dir = 4},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"iS" = (/turf/unsimulated/wall/hammereditor/dev1,/area/warfare/homebase/blue/div)
-"iU" = (/obj/machinery/light/caged{dir = 4; pixel_x = -10; pixel_y = 0},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/one)
-"iV" = (/obj/effect/floor_decal/trench{dir = 6},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/trench_section/underground)
-"iX" = (/obj/structure/closet/crate/wooden/large,/turf/simulated/floor/urban/cinder,/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
-"iZ" = (/obj/structure/closet/body_bag,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"jc" = (/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"jh" = (/obj/structure/soldiercryo/special/blue,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/stoneroom)
-"jj" = (/obj/effect/landmark/start{name = "Red Soldier"},/obj/machinery/light/small/bunker{dir = 4},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"jo" = (/obj/machinery/light/small/bunker{dir = 1},/turf/simulated/floor/wood,/area/warfare/homebase/blue/caproom)
-"jq" = (/obj/effect/floor_decal/industrial/warning/dust{dir = 4},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/blue/trainyard)
-"jr" = (/obj/machinery/light/small/bunker{dir = 4},/obj/structure/table/rack/shelf/red,/obj/item/device/cassette/greed1,/obj/item/device/cassette/greed2,/obj/item/device/cassette/greed3,/turf/simulated/floor/stones,/area/warfare/homebase/red/largeroom)
-"js" = (/obj/hammereditor/nodraw/deco/shadowpaint{opacity = 1; dir = 8},/obj/structure/train_deco/tracks01,/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/stones,/area/warfare/homebase/blue/trainyard)
-"ju" = (/obj/random/canned_food/red,/obj/random/canned_food/red,/obj/structure/table/rack/shelf/red,/obj/random/canned_food/red,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/room)
-"jv" = (/obj/machinery/light/small/red{dir = 1; pixel_y = 15},/obj/structure/closet/body_bag,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"jy" = (/obj/structure/trench_wall/sequel{dir = 1},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/indoors)
-"jz" = (/obj/structure/announcementspeaker/red{pixel_x = 0; dir = 1},/turf/simulated/floor/dirty/indestructable,/area/warfare/battlefield/trench_section)
-"jA" = (/obj/machinery/door/airlock/multi_tile/metal/maintenance{dir = 1; icon_state = "door_closed"; name = "Emergency Medical"},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"jC" = (/obj/effect/floor_decal/stones{dir = 1},/turf/simulated/floor/dirty/indestructable,/area/warfare/battlefield/capture_point/blue/one)
-"jD" = (/obj/machinery/door/airlock/multi_tile/metal/maintenance/red,/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/hallway)
-"jO" = (/obj/structure/curtain/tarp{dir = 8},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"jP" = (/turf/simulated/wall/perspecticrete,/area/warfare/homebase/red/hallway)
-"jT" = (/obj/structure/table/rack/holorack,/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/room)
-"jW" = (/obj/structure/trench_wall/sequel{dir = 4},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/red/two)
-"jZ" = (/obj/item/storage/belt/medical/full,/obj/item/storage/belt/medical/full,/obj/item/storage/belt/medical/full,/obj/item/storage/belt/medical/full,/obj/item/storage/belt/medical/full,/obj/machinery/light/caged{pixel_y = 30; pixel_x = 0},/obj/structure/trench_wall/innercorners{pixel_x = -32; pixel_y = 31},/obj/structure/trench_wall{dir = 5; pixel_x = -32; layer = 28},/obj/structure/table/rack/shelf/red,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"kb" = (/obj/structure/trench_wall/innercorners{dir = 1},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/room)
-"ke" = (/obj/structure/closet/crate,/obj/random/canned_food/blue,/obj/random/canned_food/blue,/obj/structure/table/rack/holorack,/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/room)
-"kl" = (/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/hallway)
-"km" = (/obj/structure/train_deco/tracks01,/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/stones,/area/warfare/homebase/blue/trainyard)
-"kq" = (/obj/structure/table/rack,/obj/item/storage/box/bodybags,/obj/item/storage/box/bodybags,/obj/item/storage/box/bodybags,/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/stoneroom)
-"ks" = (/obj/structure/trench_wall/innercorners{dir = 4},/turf/simulated/mineral{health = 999999},/area/space)
-"kw" = (/obj/machinery/computer/operating{dir = 1; density = 1; icon_state = "console"},/obj/machinery/light/caged{dir = 1; pixel_y = -1},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"kz" = (/obj/machinery/light/caged{pixel_y = 30; pixel_x = 0},/obj/effect/floor_decal/trench,/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/two)
-"kG" = (/obj/effect/landmark/start{name = "Blue Sentry"},/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"kK" = (/turf/simulated/floor/wood,/area/warfare/homebase/red/caproom)
-"kR" = (/obj/effect/floor_decal/industrial/direction{dir = 4},/obj/structure/sign/neon/armory{pixel_y = 32},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/hallway)
-"kS" = (/obj/structure/toilet{dir = 8; icon_state = "toilet00"},/obj/structure/trench_wall{dir = 8; pixel_x = 32; pixel_y = 0},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/room)
-"kY" = (/obj/item/storage/toolbox/mechanical{pixel_x = 5; pixel_y = 6},/obj/item/wrench{pixel_x = -15; pixel_y = 5},/obj/machinery/light{dir = 4},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/room)
-"kZ" = (/obj/machinery/door/airlock/multi_tile/metal/maintenance/blue,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/room)
-"la" = (/obj/machinery/light/caged{dir = 4; pixel_x = -1; pixel_y = 0},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"lc" = (/obj/structure/closet/crate,/obj/random/canned_food/blue,/obj/random/canned_food/blue,/obj/structure/announcementspeaker/blue{pixel_y = 0; dir = 4},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"le" = (/obj/machinery/door/airlock/multi_tile/metal/maintenance/red,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/hallway)
-"lf" = (/obj/structure/trench_wall{dir = 1},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/blue/one)
-"lh" = (/obj/structure/announcementspeaker/red{pixel_x = 0; dir = 1},/turf/simulated/open,/area/warfare/battlefield/capture_point/red/one)
-"li" = (/obj/machinery/light/small/bunker{dir = 8},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"ll" = (/obj/effect/landmark/start/redcoats,/obj/structure/bed/chair/gray{dir = 1},/turf/simulated/floor/ert/metal01,/area/train/red)
-"ls" = (/obj/structure/trench_wall{dir = 4},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/blue/one)
-"lu" = (/obj/machinery/door/airlock/multi_tile/metal/maintenance/blue,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/blue/hallway)
-"lw" = (/obj/hammereditor/nodraw/deco/shutter_quarter{dir = 1},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/room)
-"lx" = (/obj/effect/landmark/start{name = "Red Soldier"},/obj/structure/bed/chair/red{dir = 1; pixel_x = 0; pixel_y = 11; buckle_pixel_shift = "x=0;y=11"},/obj/machinery/light/small/bunker{dir = 8},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"ly" = (/obj/structure/trench_wall/innercorners{dir = 8},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/red/two)
-"lB" = (/obj/effect/floor_decal/trench{dir = 4},/obj/machinery/light/caged{pixel_y = -1; dir = 1; pixel_x = 0},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/one)
-"lE" = (/obj/machinery/light/small/bunker{dir = 1},/obj/machinery/telecomms/allinone{intercept = 1},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"lI" = (/obj/structure/trench_wall/innercorners{dir = 1; pixel_x = 32; pixel_y = 31},/obj/structure/trench_wall{dir = 8; pixel_x = 32; pixel_y = 0},/obj/structure/stairs/trenchstairs{dir = 1},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/one)
-"lK" = (/obj/structure/bed/chair/blue{dir = 1; pixel_x = 0; pixel_y = 11; buckle_pixel_shift = "x=0;y=11"},/obj/effect/landmark/start{name = "Red Soldier"},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/largeroom)
-"lL" = (/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/room)
-"lN" = (/obj/structure/announcementspeaker/red{pixel_x = 0; dir = 4},/obj/machinery/light/small/bunker{dir = 1},/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/hallway)
-"lO" = (/obj/structure/trench_wall{dir = 8; pixel_x = 32; pixel_y = 0},/obj/structure/trench_wall/innercorners{dir = 8; pixel_x = 32; pixel_y = -32},/obj/structure/trench_wall{dir = 8; pixel_x = 32; pixel_y = 0},/obj/structure/trench_wall/sequel{dir = 6; pixel_x = 0; pixel_y = -32},/obj/structure/closet/crate,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/room)
-"lV" = (/obj/structure/poster/red,/turf/simulated/wall/perspecticrete,/area/warfare/homebase/red/hallway)
-"lX" = (/obj/structure/table/rack/nosmooth/metal,/obj/item/storage/box/bodybags{pixel_x = 0; pixel_y = 11},/obj/item/storage/box/bodybags{pixel_x = 0; pixel_y = -1},/obj/machinery/light/caged{pixel_y = 30; pixel_x = 16},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"ma" = (/obj/machinery/sleeper{dir = 4; icon_state = "sleeper_0"},/obj/structure/announcementspeaker/red{id = "Bluecoats"; pixel_y = 32},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"mc" = (/obj/machinery/light/small/bunker{pixel_x = 0; pixel_y = 32},/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/stoneroom)
-"mf" = (/obj/effect/landmark/start{name = "Red Soldier"},/obj/structure/bed/chair/red,/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"mi" = (/obj/structure/window/reinforced{dir = 8; icon_state = "rwindow"},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/room)
-"ml" = (/obj/machinery/light/caged{pixel_y = -14; dir = 1; pixel_x = 0},/obj/item/device/compass,/obj/item/device/compass,/obj/structure/table/rack/nosmooth/wood,/turf/simulated/floor/stones,/area/warfare/homebase/red/room)
-"mo" = (/obj/structure/table/rack/holorack,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"ms" = (/obj/effect/landmark/start{name = "Blue Practitioner"},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"mu" = (/obj/structure/table/rack,/obj/item/storage/box/bodybags,/obj/item/storage/box/bodybags,/obj/item/storage/box/bodybags,/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/stoneroom)
-"mw" = (/turf/simulated/floor/wood,/area/warfare/homebase/blue)
-"mD" = (/obj/structure/trench_wall{dir = 1},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/red/one)
-"mJ" = (/obj/structure/table/rack/shelf/red,/obj/machinery/light/small/bunker{dir = 1},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"mL" = (/obj/effect/lighting_dummy/daylight,/obj/structure/train_deco/tracks01,/obj/hammereditor/playerclip,/turf/simulated/floor/stones,/area/warfare/homebase/blue/trainyard)
-"mN" = (/obj/machinery/light/caged{dir = 4; pixel_x = -10; pixel_y = 0},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/two)
-"mQ" = (/obj/structure/table/rack/nosmooth/wood/alt{dir = 8},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"mT" = (/obj/effect/floor_decal/trench{dir = 1},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/two)
-"mU" = (/obj/structure/closet/secure_closet/medical1/warfare,/obj/item/clothing/suit/surgeon_apron,/obj/item/clothing/suit/surgeon_apron,/obj/item/clothing/suit/surgeon_apron,/obj/item/clothing/suit/surgeon_apron,/obj/item/storage/backpack/satchel/warfare/prac/blue,/obj/item/storage/backpack/satchel/warfare/prac/blue,/obj/structure/announcementspeaker/red{id = "Bluecoats"; pixel_y = 32},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"mX" = (/obj/structure/table/rack/nosmooth/metal,/obj/item/storage/box/bodybags{pixel_x = 0; pixel_y = 11},/obj/item/storage/box/bodybags{pixel_x = 0; pixel_y = -1},/obj/machinery/light/caged{pixel_y = 30; pixel_x = 16},/obj/structure/trench_wall/innercorners{pixel_y = 32; pixel_x = -32},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"mZ" = (/obj/structure/warfare_itemeater/red{pixel_y = 32},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"nb" = (/obj/structure/curtain,/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/room)
-"nc" = (/obj/structure/lattice,/obj/machinery/light/caged{dir = 4; pixel_x = -10; pixel_y = 0},/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/underground)
-"ne" = (/obj/effect/landmark/start/redcoats,/obj/structure/bed/chair/gray,/turf/simulated/floor/ert/metal01,/area/train/red)
-"ng" = (/turf/simulated/wall/perspecticrete,/area/warfare/homebase/red/trainyard)
-"ni" = (/obj/item/storage/firstaid/adv,/obj/item/storage/firstaid/adv,/obj/item/storage/firstaid/adv,/obj/item/storage/firstaid/adv,/obj/structure/table/rack/shelf/red,/obj/machinery/light{dir = 4},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"nm" = (/turf/simulated/mineral{health = 999999},/turf/simulated/open,/area/space)
-"nn" = (/obj/machinery/light/caged{pixel_y = 30; pixel_x = 0},/obj/effect/floor_decal/trench,/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/two)
-"nq" = (/obj/effect/phone_line,/obj/item/paper_bin{pixel_x = 4; pixel_y = 10},/obj/structure/table/nosmooth/capnew{pixel_y = -4; dir = 4},/obj/item/pen/blue{pixel_x = 2; pixel_y = 10},/obj/item/storage/fancy/cigar{pixel_x = 1; pixel_y = 5},/obj/structure/table/nosmooth/capnew{pixel_y = 28; dir = 5},/obj/item/flame/lighter/zippo{pixel_x = 7; pixel_y = -1},/turf/simulated/floor/wood,/area/warfare/homebase/blue/caproom)
-"nt" = (/obj/effect/floor_decal/trench,/obj/structure/trench_wall/innercorners{pixel_x = -32; pixel_y = 31},/obj/structure/trench_wall{dir = 4; pixel_x = -32; pixel_y = 0},/obj/structure/stairs/trenchstairs{dir = 1},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/two)
-"nv" = (/obj/structure/closet/secure_closet/warfare/practicioner,/obj/item/clothing/suit/surgeon_apron,/obj/item/clothing/suit/surgeon_apron,/obj/item/clothing/gloves/latex,/obj/item/clothing/gloves/latex,/obj/item/clothing/mask/surgical,/obj/item/clothing/mask/surgical,/obj/item/storage/backpack/satchel/warfare/prac,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"nw" = (/obj/machinery/light/small/bunker{pixel_x = 0; pixel_y = 32},/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/room)
-"nx" = (/obj/effect/floor_decal/trench{dir = 8},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/two)
-"ny" = (/obj/machinery/light/caged{pixel_y = 30; pixel_x = 16},/obj/structure/trench_wall{dir = 5; pixel_x = -32; layer = 28},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"nz" = (/obj/effect/floor_decal/trench{dir = 5},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/one)
-"nA" = (/obj/structure/trench_wall/innercorners{dir = 8},/turf/simulated/mineral{health = 999999},/area/space)
-"nD" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/largeroom)
-"nJ" = (/obj/structure/trench_wall/innercorners{dir = 8},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/bunker)
-"nK" = (/obj/structure/trench_wall/sequel{dir = 8},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/blue/one)
-"nN" = (/obj/item/storage/firstaid/regular,/obj/item/storage/firstaid/regular,/obj/item/storage/firstaid/regular,/obj/item/storage/firstaid/regular,/obj/structure/table/rack/shelf/red,/obj/item/storage/firstaid/adv,/obj/item/storage/firstaid/adv,/obj/item/storage/firstaid/adv,/obj/item/storage/firstaid/adv,/obj/machinery/light/caged{pixel_y = 30},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"nP" = (/obj/effect/landmark/train_marker/exit/blue,/obj/structure/train_deco/tracks01,/turf/simulated/floor/urban/destroyed,/area/warfare/homebase/blue/trainyard)
-"nQ" = (/turf/simulated/wall/perspecticrete{integrity = 99999},/area/warfare/battlefield/trench_section/underground/indoors)
-"nV" = (/obj/structure/announcementspeaker/red{pixel_x = 0; dir = 1},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"oh" = (/obj/effect/landmark/start{name = "Red Soldier"},/obj/structure/bed/chair/red,/obj/machinery/light/small/bunker{dir = 8},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"ol" = (/obj/effect/landmark/start/bluecoats,/obj/structure/bed/chair/red{dir = 1},/turf/simulated/floor/ert/metal01,/area/train/blue)
-"om" = (/obj/structure/trench_wall{dir = 9; pixel_x = 32; pixel_y = 0; layer = 28},/obj/structure/trench_wall/innercorners{dir = 8; pixel_x = 32; pixel_y = -32},/obj/structure/table/rack/shelf/red,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"oo" = (/obj/structure/closet/crate/wooden{pixel_x = -10; pixel_y = 1},/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
-"os" = (/obj/structure/trench_wall/innercorners{dir = 1},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/red/one)
-"ot" = (/turf/simulated/floor/stones,/area/warfare/homebase/blue/room)
-"oy" = (/obj/machinery/light/small/bunker{dir = 1},/obj/item/device/boombox,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"oz" = (/obj/structure/closet/crate{name = "gasmask crate"},/obj/item/clothing/mask/gas/red,/obj/item/clothing/mask/gas/red,/obj/item/clothing/mask/gas/red,/obj/item/clothing/mask/gas/red,/obj/item/clothing/mask/gas/red,/obj/item/clothing/mask/gas/red,/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red)
-"oB" = (/obj/structure/announcementspeaker/red{pixel_x = 0; dir = 1},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/trench_section/underground)
-"oD" = (/obj/structure/curtain/medical{color = "#b8dddddd"},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/stoneroom)
-"oE" = (/obj/machinery/light/caged{dir = 4; pixel_x = -10; pixel_y = 16},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/trench_section/underground)
-"oG" = (/obj/item/clothing/accessory/medal/red/brass{pixel_x = 8; pixel_y = 2},/obj/item/clothing/accessory/medal/red/brass{pixel_x = 12; pixel_y = 2},/obj/item/clothing/accessory/medal/red/pig_iron{pixel_x = 16; pixel_y = 2},/obj/item/clothing/accessory/medal/red/gold{pixel_x = 20; pixel_y = 2},/obj/structure/table/nosmooth/capnew{pixel_y = -4; dir = 8},/obj/item/device/megaphone/red{pixel_x = -1; pixel_y = 7},/obj/structure/table/nosmooth/capnew{pixel_y = 28; dir = 9},/turf/simulated/floor/wood,/area/warfare/homebase/red/caproom)
-"oJ" = (/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/concrete/random,/area/warfare/battlefield/capture_point/blue/two)
-"oK" = (/obj/structure/defensive_barrier{dir = 1; pixel_y = 12; secured = 1},/obj/hammereditor/nodraw,/turf/simulated/wall/perspecticrete{layer = 29; plane = -150},/area/warfare/battlefield/trench_section/underground)
-"oN" = (/obj/structure/warfare_itemeater/blue,/turf/simulated/wall/perspecticrete,/area/warfare/homebase/blue/largeroom)
-"oQ" = (/obj/effect/landmark/start{name = "Blue Squad Leader"},/obj/machinery/light/small/bunker{pixel_x = 16; pixel_y = 32},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"oR" = (/obj/structure/trench_wall,/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/red/one)
-"oS" = (/obj/effect/decal/cleanable/cobweb2{dir = 1},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/hallway)
-"oT" = (/obj/machinery/light/caged{pixel_y = -2; dir = 1; pixel_x = 16},/obj/structure/trench_wall{dir = 9; pixel_x = -32; layer = 28},/obj/structure/table/rack/holorack,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"oV" = (/obj/machinery/light/caged{pixel_y = -1; dir = 1; pixel_x = 0},/turf/simulated/floor/dirty/indestructable,/area/warfare/homebase/red)
-"pb" = (/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/stoneroom)
-"pd" = (/obj/item/flame/candle,/obj/item/storage/box/matches,/obj/structure/table/rack/nosmooth/wood/alt,/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"pe" = (/obj/effect/floor_decal/industrial/outline/grey,/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/blue/trainyard)
-"ph" = (/obj/effect/floor_decal/trench{dir = 5},/obj/machinery/light/caged{pixel_y = -1; dir = 1; pixel_x = 0},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/one)
-"pm" = (/obj/machinery/light/caged{pixel_y = 30; pixel_x = 0},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/one)
-"pq" = (/obj/structure/announcementspeaker/blue{pixel_y = 0; dir = 8},/turf/simulated/open,/area/warfare/battlefield/capture_point/blue/two)
-"pr" = (/obj/effect/landmark/start{name = "Red Soldier"},/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/stones,/area/warfare/homebase/red/room)
-"pt" = (/obj/structure/announcementspeaker/red{pixel_x = 0; dir = 4},/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/room)
-"pu" = (/obj/sound_emitter/loop/env_canal,/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
-"pv" = (/obj/machinery/light/caged{dir = 8; pixel_x = 10; pixel_y = 14},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/trench_section/underground)
-"pw" = (/obj/structure/toilet{dir = 4; icon_state = "toilet00"},/turf/simulated/floor/stones,/area/warfare/homebase/blue/room)
-"px" = (/obj/effect/darkout_teleporter/redcoats,/turf/unsimulated/wall/submarine/doors,/area/train/red)
-"pC" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/hallway)
-"pF" = (/turf/simulated/wall/perspecticrete,/area/space)
-"pG" = (/obj/machinery/light/caged{pixel_y = 30; pixel_x = 0},/obj/effect/floor_decal/trench{dir = 1},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/one)
-"pI" = (/obj/machinery/light/small/bunker{dir = 8; pixel_x = 0; pixel_y = 15},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"pL" = (/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/one)
-"pS" = (/obj/structure/bed/chair/blue{dir = 1; pixel_x = 0; pixel_y = 11; buckle_pixel_shift = "x=0;y=11"},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/largeroom)
-"pV" = (/turf/simulated/open,/area/warfare/homebase/blue/stoneroom)
-"pX" = (/obj/structure/bed,/turf/simulated/floor/stones,/area/warfare/homebase/blue/room)
-"pZ" = (/obj/structure/trench_wall/sequel{dir = 4},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/blue/one)
-"qa" = (/obj/effect/floor_decal/stones{dir = 1},/turf/simulated/floor/dirty/indestructable,/area/warfare/battlefield/trench_section)
-"qb" = (/obj/effect/floor_decal/trench{dir = 5},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/two)
-"qf" = (/obj/machinery/light/caged{dir = 8; pixel_x = 10; pixel_y = 0},/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/underground)
-"qg" = (/mob/living/simple_animal/hostile/retaliate/rat,/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/one)
-"qj" = (/obj/effect/landmark/start/morale_officer,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"qk" = (/obj/structure/trench_wall/innercorners{dir = 4},/obj/structure/trench_wall{dir = 4},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/indoors)
-"ql" = (/obj/effect/floor_decal/urban/trim1{dir = 1},/obj/effect/floor_decal/urban/trim1,/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/room)
-"qm" = (/obj/machinery/light{dir = 1; pixel_y = 32},/obj/effect/floor_decal/industrial/warning/dust{dir = 4},/obj/effect/decal/cleanable/ash,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/hallway)
-"qq" = (/obj/item/storage/firstaid/surgery,/obj/structure/table/rack/nosmooth/metal,/obj/item/reagent_containers/spray/cleaner/warfare{pixel_x = 4; pixel_y = 17},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"qt" = (/obj/machinery/light/small/bunker{dir = 1},/obj/structure/table/rack/nosmooth/wood,/obj/structure/closet/crate/wooden/large/meatball{pixel_x = 0; pixel_y = 11},/obj/item/storage/toggle/envelope{pixel_x = 0; pixel_y = 0},/obj/item/storage/toggle/envelope{pixel_x = -8; pixel_y = 0},/obj/item/storage/toggle/envelope{pixel_x = 8; pixel_y = 0},/obj/item/storage/toggle/envelope{pixel_x = -8; pixel_y = -5},/obj/item/storage/toggle/envelope{pixel_x = 0; pixel_y = -5},/obj/item/storage/toggle/envelope{pixel_x = 8; pixel_y = -5},/obj/item/storage/toggle/envelope{pixel_x = -8; pixel_y = -10},/obj/item/storage/toggle/envelope{pixel_x = 0; pixel_y = -10},/obj/item/storage/toggle/envelope{pixel_x = 8; pixel_y = -10},/turf/simulated/floor/wood,/area/warfare/homebase/red/caproom)
-"qu" = (/obj/structure/trench_wall{dir = 6},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/red/one)
-"qx" = (/obj/machinery/light/caged{dir = 4; pixel_x = -10; pixel_y = 0},/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/underground)
-"qD" = (/obj/structure/announcementspeaker/red,/turf/simulated/wall/perspecticrete,/area/warfare/homebase/red/room)
-"qE" = (/obj/structure/announcementspeaker/blue{pixel_y = 32},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/trench_section/underground)
-"qF" = (/obj/machinery/vending/soldier,/turf/simulated/floor/tiled,/area/warfare/homebase/red/largeroom)
-"qG" = (/obj/structure/closet/body_bag,/obj/structure/trench_wall/innercorners{dir = 1; pixel_x = 32; pixel_y = 31},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"qH" = (/obj/structure/trench_wall/innercorners{dir = 8},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/blue/one)
-"qI" = (/obj/structure/toilet{dir = 8; icon_state = "toilet00"},/obj/structure/trench_wall{dir = 8; pixel_x = 32; pixel_y = 0},/obj/structure/trench_wall/innercorners{dir = 8; pixel_x = 32; pixel_y = -32},/obj/structure/trench_wall/sequel{dir = 6; pixel_x = 0; pixel_y = -32},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/room)
-"qL" = (/obj/structure/announcementspeaker/red{pixel_x = 0; dir = 1},/turf/simulated/floor/stones,/area/warfare/homebase/red/largeroom)
-"qO" = (/obj/machinery/light/small/bunker{dir = 1},/obj/structure/reagent_dispensers/watertank,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"qQ" = (/obj/structure/announcementspeaker/red{pixel_y = 32},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/trench_section/underground)
-"qR" = (/obj/machinery/light/caged{pixel_y = -14; dir = 1; pixel_x = 0},/turf/simulated/open,/area/warfare/battlefield/capture_point/blue/two)
-"qT" = (/obj/structure/trench_wall/innercorners{dir = 4; pixel_x = -32},/obj/structure/trench_wall/innercorners{dir = 8},/obj/structure/defensive_barrier{pixel_y = 7; secured = 1; plane = -14},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/space)
-"qW" = (/obj/effect/floor_decal/stones{dir = 4},/turf/simulated/floor/dirty/indestructable,/area/warfare/battlefield/trench_section)
-"qY" = (/turf/unsimulated/wall/submarine/doors{dir = 1},/area/train/red)
-"ra" = (/obj/effect/landmark/start{name = "Red Captain"},/obj/structure/bed/chair/throne/red{pixel_x = 0; pixel_y = -3; buckle_pixel_shift = "x=0;y=-3"},/turf/simulated/floor/wood,/area/warfare/homebase/red/caproom)
-"rb" = (/obj/effect/decal/cleanable/blood/gibs,/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"rd" = (/obj/effect/landmark/start{name = "Red Soldier"},/obj/structure/bed/chair/red{dir = 8; pixel_x = -6; pixel_y = 0; buckle_pixel_shift = "x=-6;y=0"},/obj/machinery/light/small/bunker{dir = 4},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"re" = (/obj/machinery/light/caged{pixel_x = -32; pixel_y = 0},/obj/effect/floor_decal/trench{dir = 10},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/one)
-"rf" = (/obj/structure/trench_wall/innercorners,/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/blue/two)
-"rg" = (/obj/structure/bed/chair/wheelchair,/obj/machinery/light{dir = 1; pixel_y = 32},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/stoneroom)
-"rj" = (/obj/effect/landmark/start{name = "Blue Soldier"},/obj/structure/bed/chair/blue{dir = 8},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"rk" = (/obj/structure/sign/neon/cargo{pixel_y = -32},/obj/effect/floor_decal/industrial/direction{dir = 4},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/hallway)
-"rm" = (/obj/effect/landmark/start{name = "Red Bartender"},/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/stones,/area/warfare/homebase/red/room)
-"rn" = (/obj/machinery/light/caged{pixel_y = 30; pixel_x = 0},/obj/effect/floor_decal/trench,/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/one)
-"rp" = (/obj/machinery/light/small/bunker{dir = 1},/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/hallway)
-"rq" = (/obj/structure/warfare_itemeater/blue{pixel_y = 32},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/trench_section/underground)
-"rs" = (/obj/structure/announcementspeaker/red{pixel_x = 0; dir = 1},/turf/simulated/open,/area/warfare/battlefield/capture_point/red/two)
-"rv" = (/obj/machinery/light/caged{pixel_y = 25; pixel_x = 0},/obj/structure/defensive_barrier{secured = 1; dir = 4; pixel_x = 2; pixel_y = 1},/obj/hammereditor/nodraw,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/hallway)
-"rx" = (/obj/effect/lighting_dummy/daylight,/turf/simulated/wall/perspecticrete,/area/warfare/homebase/red/trainyard)
-"ry" = (/obj/effect/floor_decal/industrial/warning/dust{dir = 4},/obj/effect/floor_decal/industrial/warning/dust,/obj/effect/lighting_dummy/daylight,/obj/effect/landmark/train_marker/teleport/red,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/red/trainyard)
-"rA" = (/obj/structure/storage/cabinet{dir = 4; pixel_x = 0; pixel_y = 3},/obj/item/ammo_magazine/handful/revolver/two{initial_ammo = 6},/obj/item/ammo_magazine/handful/revolver/two{initial_ammo = 6},/obj/item/ammo_magazine/handful/revolver/two{initial_ammo = 6},/obj/structure/announcementspeaker/blue{pixel_y = 32},/obj/item/reagent_containers/pill/cyanide{icon_state = "pill4"; name = "cyanide pill"; desc = "It's marked 'KCN'. Smells vaguely of almonds. Your last resort.."},/obj/item/reagent_containers/pill/cyanide{icon_state = "pill4"; name = "cyanide pill"; desc = "It's marked 'KCN'. Smells vaguely of almonds. Your last resort.."},/obj/item/reagent_containers/pill/cyanide{icon_state = "pill4"; name = "cyanide pill"; desc = "It's marked 'KCN'. Smells vaguely of almonds. Your last resort.."},/turf/simulated/floor/wood,/area/warfare/homebase/blue/caproom)
-"rB" = (/obj/structure/table/rack/shelf/red,/turf/simulated/wall/perspecticrete,/area/warfare/homebase/red/largeroom)
-"rC" = (/obj/machinery/button/remote/blast_door/lever,/obj/hammereditor/nodraw,/turf/simulated/wall/perspecticrete,/area/warfare/homebase/blue/room)
-"rF" = (/obj/machinery/light/small/bunker{dir = 4},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/hallway)
-"rI" = (/obj/structure/trench_wall,/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/red/two)
-"rJ" = (/obj/effect/landmark/train_marker/entry/blue,/obj/structure/train_deco/tracks01,/obj/hammereditor/nodraw/deco/shadowpaint{opacity = 1; dir = 8},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/stones,/area/warfare/homebase/blue/trainyard)
-"rK" = (/obj/structure/toilet{dir = 8; icon_state = "toilet00"},/obj/machinery/light/small/bunker{pixel_x = 0; pixel_y = 32},/turf/simulated/floor/stones,/area/warfare/homebase/blue/room)
-"rM" = (/turf/simulated/wall/perspecticrete,/area/warfare/homebase/blue/room)
-"rN" = (/obj/effect/landmark/start/redcoats,/obj/machinery/light/small,/obj/structure/bed/chair/gray{dir = 1},/turf/simulated/floor/ert/metal01,/area/train/red)
-"rT" = (/obj/machinery/light/small/bunker{pixel_x = 0; pixel_y = 32},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/hallway)
-"rV" = (/obj/effect/floor_decal/urban/trim1,/turf/simulated/floor/urban/cinder,/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
-"rZ" = (/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/stoneroom)
-"sg" = (/obj/structure/table/rack/nosmooth/metal,/obj/machinery/light/small/bunker{dir = 8; pixel_x = 0; pixel_y = 15},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"sk" = (/obj/machinery/light/small/bunker{dir = 1},/obj/structure/table/rack/nosmooth/wood,/obj/structure/closet/crate/wooden/large/meatball{pixel_x = 0; pixel_y = 11},/obj/item/storage/toggle/envelope{pixel_x = 0; pixel_y = 0},/obj/item/storage/toggle/envelope{pixel_x = -8; pixel_y = 0},/obj/item/storage/toggle/envelope{pixel_x = 8; pixel_y = 0},/obj/item/storage/toggle/envelope{pixel_x = -8; pixel_y = -5},/obj/item/storage/toggle/envelope{pixel_x = 0; pixel_y = -5},/obj/item/storage/toggle/envelope{pixel_x = 8; pixel_y = -5},/obj/item/storage/toggle/envelope{pixel_x = -8; pixel_y = -10},/obj/item/storage/toggle/envelope{pixel_x = 0; pixel_y = -10},/obj/item/storage/toggle/envelope{pixel_x = 8; pixel_y = -10},/turf/simulated/floor/wood,/area/warfare/homebase/blue/caproom)
-"sm" = (/obj/structure/bed/roller,/obj/machinery/light{dir = 4},/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/stoneroom)
-"sn" = (/obj/structure/table/rack/nosmooth/wood/alt,/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"sr" = (/obj/structure/trench_wall{dir = 6},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/indoors)
-"sw" = (/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/hallway)
-"sx" = (/obj/structure/trench_wall/innercorners{dir = 4},/obj/structure/trench_wall/innercorners{dir = 8; pixel_x = 32},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/space)
-"sz" = (/obj/item/storage/firstaid/toxin,/obj/item/storage/firstaid/toxin,/obj/item/storage/firstaid/toxin,/obj/item/storage/firstaid/toxin,/obj/structure/table/rack/shelf/red,/obj/structure/table/woodentable/shelf{pixel_y = 26; density = 0},/obj/item/reagent_containers/rag{pixel_x = -5; pixel_y = 28},/obj/item/reagent_containers/glass/bottle/antique/slim/chloroform{pixel_x = 1; pixel_y = 31; icon_state = "slim_rd"},/obj/item/reagent_containers/glass/bottle/antique/slim/chloroform{pixel_x = 10; pixel_y = 32; icon_state = "slim_rd"},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"sA" = (/obj/structure/trench_wall{dir = 8},/turf/simulated/mineral{health = 999999},/area/space)
-"sB" = (/obj/structure/trench_wall/innercorners{dir = 8},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground)
-"sE" = (/obj/machinery/light/small/bunker{dir = 1},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/hallway)
-"sJ" = (/turf/space,/area/warfare/homebase/blue/trainyard)
-"sK" = (/obj/machinery/light/small/bunker{pixel_x = 0; pixel_y = 32},/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/hallway)
-"sL" = (/obj/machinery/light/caged{pixel_y = -1; dir = 1; pixel_x = 0},/obj/structure/table/rack/shelf/red,/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/room)
-"sN" = (/obj/hammereditor/nodraw/deco/shadowpaint,/turf/simulated/floor/stones,/area/warfare/homebase/red/trainyard)
-"sU" = (/obj/item/paper/crumpled,/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
-"sW" = (/obj/structure/trench_wall{dir = 8},/obj/hammereditor/nodraw/deco/shadowpaint{dir = 1},/turf/simulated/mineral{health = 999999},/area/space)
-"sY" = (/obj/machinery/light{dir = 1; pixel_y = 32},/turf/simulated/floor/tiled/ramp{dir = 8; icon_state = "ramptop"},/area/warfare/homebase/blue/stoneroom)
-"tb" = (/obj/structure/table/woodentable/shelf{pixel_y = 13},/turf/simulated/floor/stones,/area/warfare/homebase/blue/largeroom)
-"tc" = (/obj/effect/floor_decal/trench{dir = 8},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/two)
-"tg" = (/obj/structure/table/woodentable/shelf{pixel_y = 13},/obj/item/device/boombox/stationary{pixel_x = 1; pixel_y = 16},/turf/simulated/floor/stones,/area/warfare/homebase/red/largeroom)
-"tj" = (/obj/machinery/light/caged{pixel_y = -1; dir = 1; pixel_x = 0},/turf/simulated/floor/wood,/area/warfare/homebase/red)
-"tk" = (/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/hallway)
-"tn" = (/obj/hammereditor/nodraw,/turf/simulated/floor/ert/metal01,/area/train/red)
-"ts" = (/obj/machinery/light,/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/room)
-"tu" = (/obj/structure/trench_wall/sequel{dir = 8},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/red/two)
-"ty" = (/obj/effect/landmark/start{name = "Blue Soldier"},/obj/machinery/light/small/bunker{dir = 8},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"tA" = (/obj/machinery/light/small/bunker{dir = 4; pixel_x = 0; pixel_y = 15},/obj/structure/phone/rotary/admin/red,/obj/structure/table/rack/nosmooth/metal,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"tI" = (/obj/machinery/bodyscanner{dir = 4; icon_state = "body_scanner_0"},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"tN" = (/obj/machinery/light/small/bunker{dir = 4},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"tR" = (/obj/effect/lighting_dummy/daylight,/obj/structure/train_deco/tracks01,/obj/effect/landmark/train_marker/idle/blue{pixel_y = 16},/obj/effect/landmark/train_marker/teleport/blue,/turf/simulated/floor/stones,/area/warfare/homebase/blue/trainyard)
-"tT" = (/obj/random/canned_food/red,/obj/random/canned_food/red,/obj/random/canned_food/red,/obj/structure/table/rack/shelf/red,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/room)
-"tW" = (/obj/structure/trench_wall{dir = 10},/obj/hammereditor/nodraw,/turf/simulated/mineral{health = 999999},/area/space)
-"tX" = (/obj/machinery/door/airlock/multi_tile/metal/maintenance/blue,/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/stoneroom)
-"ua" = (/obj/machinery/door/blast/shutters{dir = 2},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/room)
-"uc" = (/obj/structure/cargo_pad/red,/obj/structure/window/reinforced{dir = 4; icon_state = "rwindow"},/obj/machinery/light/small/bunker{pixel_x = 0; pixel_y = 32},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/room)
-"uf" = (/obj/structure/table/rack/nosmooth/wood/alt{dir = 10},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"ug" = (/obj/machinery/light/small/bunker{dir = 4},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"ui" = (/obj/effect/floor_decal/industrial/warning/dust/corner{dir = 1},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/blue/trainyard)
-"uj" = (/obj/effect/floor_decal/trench{dir = 8},/obj/machinery/light/caged{pixel_y = -1; dir = 1; pixel_x = 0},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/one)
-"ul" = (/obj/machinery/light/small/bunker{dir = 8; pixel_x = 0; pixel_y = 15},/obj/structure/phone/rotary/admin,/obj/structure/table/rack/nosmooth/metal,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"um" = (/obj/structure/trench_wall/innercorners{dir = 1; pixel_x = 32; pixel_y = 31},/obj/structure/trench_wall{dir = 8; pixel_x = 32; pixel_y = 0},/obj/structure/stairs/trenchstairs{dir = 1},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/two)
-"ur" = (/obj/structure/toilet{dir = 4; icon_state = "toilet00"},/turf/simulated/floor/stones,/area/warfare/homebase/red/room)
-"us" = (/obj/machinery/light/small/bunker,/turf/simulated/wall/perspecticrete,/area/warfare/homebase/blue/largeroom)
-"uw" = (/obj/structure/closet/secure_closet/medical1/warfare,/obj/item/clothing/suit/surgeon_apron,/obj/item/clothing/suit/surgeon_apron,/obj/item/clothing/suit/surgeon_apron,/obj/item/clothing/suit/surgeon_apron,/obj/item/storage/backpack/satchel/warfare/prac,/obj/item/storage/backpack/satchel/warfare/prac,/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/room)
-"uz" = (/obj/structure/trench_wall,/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/blue/two)
-"uA" = (/turf/simulated/mineral{health = 999999},/area/warfare/homebase/red/largeroom)
-"uB" = (/obj/effect/landmark/start{name = "Blue Soldier"},/obj/machinery/light/small/bunker{dir = 4},/obj/structure/bed/chair/blue,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"uC" = (/obj/item/flame/candle,/obj/item/device/compass,/obj/item/device/compass,/obj/item/device/compass,/obj/structure/table/rack/nosmooth/wood/alt{dir = 6},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"uD" = (/obj/machinery/light/small/bunker{pixel_x = 0; pixel_y = 32},/obj/structure/announcementspeaker/blue{pixel_y = 0; dir = 8},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"uH" = (/obj/structure/announcementspeaker/red{id = "Bluecoats"; dir = 4},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/hallway)
-"uK" = (/obj/machinery/light{dir = 8},/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/stoneroom)
-"uL" = (/obj/structure/table/nosmooth/capnew{pixel_y = -4},/obj/item/device/flashlight/lamp/captain/blue{pixel_x = 15; pixel_y = 9},/obj/structure/announcementmicrophone/blue{pixel_x = -14; pixel_y = 12; plane = -60},/obj/item/waxstamp/blue{pixel_x = 8; pixel_y = 9},/obj/item/storage/toggle/envelope{pixel_x = 0; pixel_y = 3},/obj/item/storage/toggle/envelope{pixel_x = 0; pixel_y = 0},/turf/simulated/floor/wood,/area/warfare/homebase/blue/caproom)
-"uN" = (/obj/structure/trench_wall{dir = 1},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/red/two)
-"uO" = (/obj/effect/floor_decal/industrial/warning/dust/corner{dir = 4},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/blue/trainyard)
-"uP" = (/obj/structure/dirt_wall,/turf/simulated/floor/dirty/indestructable,/area/warfare/battlefield/trench_section/hallway)
-"uS" = (/obj/structure/table/rack,/obj/machinery/light{dir = 1; pixel_y = 32},/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/stoneroom)
-"uW" = (/obj/effect/floor_decal/trench{dir = 10},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/one)
-"uX" = (/obj/structure/train_deco/tracks01,/obj/effect/landmark/train_marker/exit/red,/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/stones,/area/warfare/homebase/red/trainyard)
-"va" = (/obj/structure/trench_wall{dir = 8},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/bunker)
-"vb" = (/obj/hammereditor/nodraw/deco/shadowpaint{opacity = 1; dir = 4},/obj/hammereditor/nodraw/deco/shadowpaint{opacity = 1; dir = 1},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/stones,/area/warfare/homebase/blue/trainyard)
-"vd" = (/obj/structure/trench_wall{dir = 4},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/red/two)
-"vg" = (/obj/item/flame/candle,/obj/item/storage/box/matches,/obj/structure/table/rack/nosmooth/wood/alt{dir = 6},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"vh" = (/obj/machinery/light/small/bunker{pixel_x = 0; pixel_y = 32},/obj/structure/announcementspeaker/red{pixel_x = 0; dir = 8},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"vk" = (/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"vl" = (/obj/effect/floor_decal/urban/trim1,/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/hallway)
-"vn" = (/obj/item/flame/lighter/zippo{name = "History"; desc = "To destroy the old, from wildlife to simple documents - history can be destroyed with a single motion of the thumb"},/obj/structure/table/rack/nosmooth/wood/alt{dir = 9},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"vo" = (/turf/simulated/wall/perspecticrete{color = "#000000"},/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
-"vr" = (/obj/effect/structure{anchored = 1; icon = 'icons/obj/power.dmi'; icon_state = "smes"; layer = 222},/obj/effect/floor_decal/industrial/warning/dust/corner{dir = 4},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/hallway)
-"vt" = (/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/largeroom)
-"vu" = (/obj/structure/defensive_barrier{dir = 1; pixel_y = 12; secured = 1},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/trench_section/underground)
-"vz" = (/obj/structure/announcementspeaker/blue{pixel_y = 0; dir = 4},/turf/simulated/open,/area/warfare/battlefield/capture_point/blue/two)
-"vA" = (/obj/structure/curtain,/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/stoneroom)
-"vC" = (/obj/machinery/optable{dir = 8; pixel_x = 6; pixel_y = 4},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"vE" = (/obj/effect/sub_marker/float{id = "SUB_END"},/turf/simulated/mineral{health = 999999},/area/warfare/homebase/red)
-"vH" = (/obj/hammereditor/nodraw/deco/shutter_quarter{dir = 4},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/room)
-"vK" = (/obj/effect/landmark/start{name = "Blue Scavenger"},/turf/simulated/floor/stones,/area/warfare/homebase/blue/room)
-"vM" = (/obj/structure/toilet{dir = 4; icon_state = "toilet00"},/obj/machinery/light/caged{pixel_y = 30; pixel_x = 0},/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/room)
-"vN" = (/obj/machinery/light/caged{pixel_y = 25; pixel_x = 0},/turf/simulated/floor/dirty/indestructable,/area/warfare/homebase/blue)
-"vP" = (/obj/effect/landmark/start{name = "Blue Soldier"},/obj/structure/bed/chair/blue{dir = 1; pixel_x = 0; pixel_y = 11; buckle_pixel_shift = "x=0;y=11"},/obj/machinery/light/small/bunker{dir = 8},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"vQ" = (/obj/machinery/light/small/bunker{pixel_x = 0; pixel_y = 32},/obj/structure/table/rack/nosmooth/wood/alt,/obj/structure/bed/chair/red,/obj/structure/bed/chair/red{pixel_x = -1; pixel_y = 6},/obj/structure/bed/chair/red{pixel_x = 1; pixel_y = 13},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"vR" = (/obj/structure/announcementspeaker/blue{pixel_x = 0; dir = 1},/turf/simulated/floor/dirty/indestructable,/area/warfare/battlefield/capture_point/blue/one)
-"vS" = (/obj/machinery/door/unpowered/simple/wood/captain{initial_lock_value = "red"; locked = 1},/obj/hammereditor/nodraw,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"vU" = (/obj/machinery/light/caged{pixel_y = 30; pixel_x = 0},/turf/simulated/open,/area/warfare/battlefield/capture_point/red/two)
-"vW" = (/obj/machinery/light/caged{pixel_y = -1; dir = 1; pixel_x = 0},/turf/simulated/floor/dirty/indestructable,/area/warfare/battlefield/trench_section)
-"vX" = (/obj/structure/curtain/medical{color = "#b8dddddd"},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/room)
-"vY" = (/obj/hammereditor/nodraw/deco/shadowpaint{opacity = 1; dir = 4},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/stones,/area/warfare/homebase/red/trainyard)
-"wc" = (/obj/effect/floor_decal/trench{dir = 6},/obj/structure/banner/blue/small{pixel_y = 32},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/one)
-"we" = (/obj/hammereditor/nodraw/deco/shadowpaint{opacity = 1; dir = 4},/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
-"wh" = (/obj/structure/train_deco/platform{pixel_y = 3},/obj/hammereditor/playerclip,/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/stones,/area/warfare/homebase/red/trainyard)
-"wj" = (/obj/structure/defensive_barrier{dir = 1; pixel_y = 12; secured = 1},/obj/structure/barbwire,/obj/hammereditor/nodraw,/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/hallway)
-"wl" = (/obj/machinery/light/caged{pixel_y = 30; pixel_x = 0},/obj/structure/closet/crate,/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/room)
-"wo" = (/obj/structure/trench_wall/innercorners{dir = 4},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/indoors)
-"wq" = (/obj/effect/floor_decal/trench{dir = 5},/obj/machinery/light/caged{pixel_y = -1; dir = 1; pixel_x = 0},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/two)
-"wu" = (/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/hallway)
-"wv" = (/obj/effect/landmark/start{name = "Blue Soldier"},/obj/structure/bed/chair/blue{dir = 4},/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"wz" = (/obj/machinery/light/small/bunker{pixel_x = 0; pixel_y = 32},/turf/simulated/floor/stones,/area/warfare/homebase/red/room)
-"wA" = (/obj/structure/table/rack,/obj/machinery/light{dir = 1; pixel_y = 32},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/stoneroom)
-"wC" = (/turf/simulated/floor/urban/destroyed,/area/warfare/homebase/blue/trainyard)
-"wF" = (/obj/structure/trench_wall/sequel{dir = 8},/obj/structure/trench_wall{dir = 9},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/indoors)
-"wG" = (/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
-"wJ" = (/obj/effect/floor_decal/trench{dir = 4},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/two)
-"wK" = (/obj/structure/trench_wall{dir = 10},/turf/simulated/mineral{health = 999999},/area/space)
-"wR" = (/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/hallway)
-"wU" = (/obj/structure/train_deco/sides{dir = 1},/obj/effect/lighting_dummy/daylight,/obj/hammereditor/playerclip,/turf/simulated/floor/stones,/area/warfare/homebase/blue/trainyard)
-"wV" = (/obj/structure/sign/medholo,/turf/simulated/wall/perspecticrete,/area/warfare/homebase/red/room)
-"wX" = (/turf/unsimulated/wall/submarine/doors{dir = 1},/area/warfare/homebase/blue/room)
-"wZ" = (/obj/structure/window/reinforced,/obj/structure/cargo_pad/blue,/obj/structure/window/reinforced{dir = 4; icon_state = "rwindow"},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/room)
-"xc" = (/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/hallway)
-"xd" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/hallway)
-"xe" = (/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue)
-"xf" = (/obj/machinery/door/airlock/multi_tile/metal/maintenance/red{locked = 1; maxhealth = 500000},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/homebase/red/hallway)
-"xj" = (/obj/structure/trench_wall/sequel{dir = 8},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/indoors)
-"xm" = (/turf/simulated/floor/stones,/area/warfare/homebase/blue/trainyard)
-"xo" = (/obj/machinery/light/small/bunker{dir = 8},/obj/structure/soldiercryo/special/blue,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/stoneroom)
-"xp" = (/turf/simulated/floor/ert/metal01,/area/train/blue)
-"xq" = (/obj/item/storage/firstaid/regular,/obj/item/storage/firstaid/regular,/obj/item/storage/firstaid/regular,/obj/item/storage/firstaid/regular,/obj/structure/table/rack/shelf/red,/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"xt" = (/obj/structure/train_deco/tracks01,/obj/hammereditor/nodraw/deco/shadowpaint{opacity = 1; dir = 4},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/stones,/area/warfare/homebase/red/trainyard)
-"xw" = (/obj/effect/sub_marker/float{id = "MISSION"},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield)
-"xx" = (/obj/machinery/light/caged{dir = 8; pixel_x = 10; pixel_y = 0},/obj/effect/floor_decal/trench{dir = 5},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/two)
-"xC" = (/obj/structure/trench_wall/innercorners,/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground)
-"xI" = (/obj/structure/bed/chair/blue{dir = 1; pixel_x = 0; pixel_y = 11; buckle_pixel_shift = "x=0;y=11"},/obj/effect/landmark/start{name = "Blue Soldier"},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/largeroom)
-"xK" = (/obj/item/flame/candle,/obj/item/ammo_box/shotgun,/obj/structure/table/rack/nosmooth/wood/alt{dir = 6},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"xL" = (/obj/machinery/door/unpowered/simple/wood/captain{initial_lock_value = "red"; locked = 1},/obj/structure/defensive_barrier{pixel_y = -4; secured = 1; plane = -14},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/indoors)
-"xM" = (/obj/structure/reagent_dispensers/watertank{pixel_x = 3; pixel_y = 0},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/room)
-"xR" = (/obj/machinery/light/small/bunker,/turf/simulated/wall/perspecticrete,/area/warfare/homebase/red/largeroom)
-"xS" = (/obj/machinery/door/unpowered/simple/wood/captain{initial_lock_value = "captain"; locked = 1},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/caproom)
-"xV" = (/obj/structure/trench_wall{dir = 10},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/bunker)
-"xW" = (/obj/effect/floor_decal/trench{dir = 4},/obj/structure/stairs/trenchstairs{dir = 1},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/two)
-"xZ" = (/obj/structure/toilet{dir = 8; icon_state = "toilet00"},/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/room)
-"yf" = (/obj/effect/floor_decal/industrial/warning/dust/corner{dir = 8},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/red/trainyard)
-"yg" = (/obj/effect/floor_decal/urban/trim1,/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/hallway)
-"yh" = (/obj/machinery/optable{pixel_x = 4},/obj/machinery/light{dir = 1; pixel_y = 32},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"yj" = (/obj/machinery/light{dir = 1; pixel_y = 32},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/hallway)
-"yn" = (/obj/structure/railing/urban{dir = 4},/obj/effect/lighting_dummy/daylight,/obj/hammereditor/playerclip,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/blue/trainyard)
-"yo" = (/obj/structure/trench_wall{dir = 8},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground)
-"yq" = (/obj/effect/darkout_teleporter/bluecoats,/obj/effect/floor_decal/train_deco/stripes{dir = 4; pixel_y = 11},/obj/effect/floor_decal/industrial/warning/dust,/obj/effect/landmark/train_marker/teleport/red,/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/red/trainyard)
-"ys" = (/obj/effect/lighting_dummy/daylight,/obj/structure/train_deco/tracks01,/obj/effect/landmark/train_marker/teleport/blue,/turf/simulated/floor/stones,/area/warfare/homebase/blue/trainyard)
-"yt" = (/obj/hammereditor/nodraw/deco/bars,/obj/hammereditor/nodraw/deco/bars{pixel_y = 10},/obj/hammereditor/nodraw,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"yv" = (/obj/effect/floor_decal/trench{dir = 4},/obj/structure/stairs/trenchstairs{dir = 1},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/one)
-"yx" = (/obj/structure/table/rack/shelf/red,/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/room)
-"yA" = (/obj/structure/trench_wall{dir = 9; pixel_x = 32; pixel_y = 0; layer = 28},/obj/structure/trench_wall/innercorners{dir = 8; pixel_x = 32; pixel_y = -32},/obj/structure/table/rack/holorack,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"yB" = (/obj/item/storage/fancy/cigarettes/luckystars,/obj/item/flame/candle,/obj/item/flame/lighter/random,/obj/item/ammo_box/rifle,/obj/structure/table/rack/nosmooth/wood/alt,/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"yE" = (/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/room)
-"yF" = (/obj/hammereditor/nodraw,/turf/simulated/wall/perspecticrete,/area/warfare/homebase/red/hallway)
-"yG" = (/obj/machinery/light/caged{pixel_x = 33; pixel_y = 0},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/two)
-"yH" = (/obj/structure/trench_wall/innercorners,/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/room)
-"yJ" = (/obj/machinery/door/blast/shutters,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/room)
-"yK" = (/obj/structure/table/rack/holorack,/turf/simulated/floor/stones,/area/warfare/homebase/blue/largeroom)
-"yP" = (/obj/structure/curtain,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/room)
-"yR" = (/obj/machinery/light/caged{pixel_y = -14; dir = 1; pixel_x = 0},/turf/simulated/floor/dirty/indestructable,/area/warfare/homebase/red)
-"yS" = (/obj/machinery/door/blast/shutters{dir = 8},/turf/simulated/wall/perspecticrete,/area/space)
-"yT" = (/obj/structure/trench_wall{dir = 8},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/red/two)
-"yZ" = (/obj/structure/table/rack/nosmooth/metal,/obj/item/storage/firstaid/surgery,/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"za" = (/obj/effect/decal/cleanable/cobweb,/obj/structure/table/rack/nosmooth/metal,/obj/item/clothing/gloves/latex{pixel_x = 0; pixel_y = 2},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"zc" = (/turf/unsimulated/wall/hammereditor/dev2,/area/warfare/homebase/red)
-"zd" = (/obj/structure/railing/urban{dir = 4},/obj/hammereditor/playerclip,/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/red/trainyard)
-"ze" = (/obj/structure/closet/secure_closet/medical1/warfare,/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/room)
-"zg" = (/obj/structure/trench_wall{dir = 4},/turf/simulated/mineral{health = 999999},/area/space)
-"zl" = (/obj/effect/floor_decal/industrial/direction{dir = 4},/obj/structure/sign/neon/cargo{pixel_y = -32},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/hallway)
-"zq" = (/obj/structure/trench_wall{dir = 1},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/blue/two)
-"zs" = (/obj/machinery/light/caged{pixel_y = -1; dir = 1; pixel_x = 0},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/two)
-"zv" = (/obj/effect/landmark/start/bluecoats,/obj/machinery/light/small,/obj/structure/bed/chair/red{dir = 1},/turf/simulated/floor/ert/metal01,/area/train/blue)
-"zz" = (/obj/structure/trench_wall,/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/room)
-"zA" = (/obj/structure/trench_wall/innercorners{dir = 1},/turf/simulated/mineral{health = 999999},/area/space)
-"zB" = (/obj/machinery/light/small/bunker{dir = 1},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"zD" = (/obj/effect/floor_decal/trench{dir = 10},/obj/machinery/light/caged{pixel_y = -1; dir = 1; pixel_x = 0},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/two)
-"zG" = (/obj/machinery/light/small/bunker{dir = 8},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/hallway)
-"zI" = (/obj/structure/table/rack/holorack,/obj/structure/closet/crate{pixel_x = 1; pixel_y = 16},/obj/structure/closet/crate,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/room)
-"zJ" = (/obj/structure/cargo_pad/red/captain,/obj/structure/warfare_itemeater/red{pixel_y = 32},/turf/simulated/floor/wood,/area/warfare/homebase/red/caproom)
-"zK" = (/obj/machinery/door/airlock/multi_tile/metal/maintenance/red,/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/hallway)
-"zM" = (/obj/structure/defensive_barrier{pixel_y = -4; secured = 1; plane = -14},/obj/structure/barbwire,/obj/hammereditor/nodraw,/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/hallway)
-"zO" = (/obj/structure/trench_wall/innercorners,/obj/structure/trench_wall{dir = 1},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/room)
-"zQ" = (/obj/machinery/door/airlock/bunker/blue,/turf/simulated/floor/stones,/area/warfare/homebase/blue/largeroom)
-"zR" = (/obj/structure/trench_wall/innercorners{dir = 4},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/blue/one)
-"zT" = (/obj/structure/train_deco/tracks01,/obj/effect/landmark/train_marker/entry/red,/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/stones,/area/warfare/homebase/red/trainyard)
-"zU" = (/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/underground)
-"zV" = (/obj/structure/closet/crate/wooden{pixel_x = -3; pixel_y = 1},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/blue/trainyard)
-"zW" = (/obj/structure/announcementspeaker/blue{pixel_x = 0; pixel_y = 32},/turf/simulated/floor/wood,/area/warfare/homebase/blue)
-"Aa" = (/obj/machinery/light/caged{dir = 4; pixel_x = -2; pixel_y = 0},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/room)
-"Ac" = (/turf/simulated/floor/dirty/indestructable,/area/warfare/battlefield/capture_point/red/one)
-"Ad" = (/obj/machinery/light/small/bunker{dir = 4},/obj/structure/table/rack/holorack,/obj/item/device/cassette/greed3,/obj/item/device/cassette/greed2,/obj/item/device/cassette/greed1,/turf/simulated/floor/stones,/area/warfare/homebase/blue/largeroom)
-"Ag" = (/obj/effect/landmark/start{name = "Red Practitioner"},/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/room)
-"Ai" = (/turf/simulated/wall/perspecticrete,/area/warfare/homebase/blue/hallway)
-"Aj" = (/obj/effect/floor_decal/industrial/warning/dust{dir = 1},/obj/effect/floor_decal/train_deco/stripes{dir = 4},/obj/structure/train_deco/platform{pixel_y = 16; dir = 4},/obj/effect/lighting_dummy/daylight,/obj/effect/darkout_teleporter/bluecoats,/obj/effect/landmark/train_marker/teleport/blue,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/blue/trainyard)
-"Ak" = (/obj/effect/lighting_dummy/daylight,/obj/machinery/camera{dir = 8; pixel_x = -2; pixel_y = 0},/turf/simulated/floor/urban/concrete,/area/warfare/homebase/blue/trainyard)
-"Al" = (/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/hallway)
-"Ao" = (/obj/structure/announcementspeaker/red{pixel_y = 32},/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/room)
-"As" = (/obj/machinery/light/caged{pixel_y = -2; dir = 1; pixel_x = 16},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"AA" = (/obj/structure/curtain,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/room)
-"AB" = (/turf/simulated/floor/exoplanet/water/shallow/lightless/urban,/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
-"AH" = (/obj/item/folder/envelope{name = "Dictates"; desc = "To pass thy dictates to thy chosen envoys. Or to dispatch reward."},/obj/structure/table/rack/nosmooth/wood/alt{dir = 9},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"AK" = (/obj/structure/trench_wall/innercorners{dir = 4},/obj/structure/trench_wall/innercorners{dir = 8; pixel_x = 32},/obj/structure/defensive_barrier{pixel_y = 7; secured = 1; plane = -14},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/space)
-"AL" = (/obj/item/disk/nuclear{name = "Powerlessness"; desc = "A trump card wielded by a powerless autarch - an ace in the hole the gods forbade him to play. How tragic"},/obj/machinery/light/small/bunker{pixel_x = 0; pixel_y = 32},/obj/structure/table/rack/nosmooth/wood/alt{dir = 6},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"AM" = (/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/wood,/area/warfare/homebase/red/caproom)
-"AO" = (/obj/structure/closet/crate/wooden/hardhats,/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
-"AP" = (/obj/structure/dirt_wall,/obj/structure/announcementspeaker/red{pixel_x = 0; dir = 8},/turf/simulated/floor/dirty/indestructable,/area/warfare/battlefield/trench_section)
-"AR" = (/obj/structure/trench_wall/sequel{dir = 8},/obj/structure/trench_wall/innercorners{dir = 4; pixel_x = -32},/turf/simulated/mineral{health = 999999},/area/space)
-"AT" = (/obj/machinery/light/small{dir = 1; pixel_y = 32},/turf/simulated/floor/urban/cinder,/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
-"AU" = (/obj/structure/table/rack/nosmooth/wood/alt{dir = 5},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"AV" = (/obj/machinery/light/caged{pixel_y = -14; dir = 1; pixel_x = -16},/obj/structure/defensive_barrier{secured = 1; dir = 4; pixel_x = 2; pixel_y = 1},/obj/hammereditor/nodraw,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/hallway)
-"AW" = (/obj/structure/trench_wall{dir = 6},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground)
-"AX" = (/turf/simulated/mineral{health = 999999},/area/warfare/homebase/blue/room)
-"Bb" = (/obj/structure/soldiercryo/special/red,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/room)
-"Bc" = (/obj/structure/closet/crate,/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"Be" = (/obj/effect/landmark/start{name = "Blue Engineer"},/obj/structure/announcementspeaker/blue{pixel_x = 0; dir = 1},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"Bi" = (/obj/structure/closet/crate,/obj/random/canned_food/red,/obj/random/canned_food/red,/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"Bo" = (/obj/structure/trench_wall/innercorners{dir = 4},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground)
-"Bq" = (/obj/effect/landmark/start{name = "Blue Soldier"},/obj/machinery/light/caged{pixel_y = -14; dir = 1; pixel_x = -16},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"Br" = (/turf/simulated/wall/perspecticrete,/area/warfare/homebase/red/largeroom)
-"Bs" = (/obj/structure/vehicle/train/long_passenger{pixel_y = 16; id = "Bluecoats"; carriage_amount = 2},/turf/space,/area/space)
-"Bu" = (/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/room)
-"By" = (/obj/structure/storage/cabinet{dir = 4; pixel_x = 0; pixel_y = 3},/obj/item/ammo_magazine/handful/revolver/two{initial_ammo = 6},/obj/item/ammo_magazine/handful/revolver/two{initial_ammo = 6},/obj/item/ammo_magazine/handful/revolver/two{initial_ammo = 6},/obj/structure/announcementspeaker/red{pixel_y = 32},/obj/item/reagent_containers/pill/cyanide{icon_state = "pill4"; name = "cyanide pill"; desc = "It's marked 'KCN'. Smells vaguely of almonds. Your last resort.."},/obj/item/reagent_containers/pill/cyanide{icon_state = "pill4"; name = "cyanide pill"; desc = "It's marked 'KCN'. Smells vaguely of almonds. Your last resort.."},/obj/item/reagent_containers/pill/cyanide{icon_state = "pill4"; name = "cyanide pill"; desc = "It's marked 'KCN'. Smells vaguely of almonds. Your last resort.."},/obj/item/crowbar/red,/turf/simulated/floor/wood,/area/warfare/homebase/red/caproom)
-"Bz" = (/obj/machinery/light{dir = 1; pixel_y = 32},/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"BC" = (/turf/simulated/mineral{health = 999999},/area/warfare/homebase/red/hallway)
-"BD" = (/obj/structure/trench_wall{dir = 6},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/red/two)
-"BE" = (/obj/item/gun/projectile/warfare/shig,/turf/simulated/floor/urban/cinder,/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
-"BH" = (/obj/effect/floor_decal/trench{dir = 6},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/two)
-"BI" = (/turf/simulated/wall/perspecticrete,/area/warfare/homebase/blue/trainyard)
-"BK" = (/obj/effect/floor_decal/industrial/warning/dust{dir = 1},/obj/effect/darkout_teleporter/bluecoats,/obj/structure/train_deco/platform{pixel_y = 16; dir = 1},/obj/effect/lighting_dummy/daylight,/obj/effect/landmark/train_marker/teleport/blue,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/blue/trainyard)
-"BM" = (/obj/structure/table/nosmooth/capnew{pixel_y = -4},/obj/structure/announcementmicrophone/red{pixel_x = -14; pixel_y = 12; plane = -60},/obj/item/device/flashlight/lamp/captain{pixel_x = 15; pixel_y = 9},/obj/item/waxstamp{pixel_x = 7; pixel_y = 9},/obj/item/storage/toggle/envelope{pixel_x = -2; pixel_y = 2},/obj/item/storage/toggle/envelope{pixel_x = -1; pixel_y = 1},/turf/simulated/floor/wood,/area/warfare/homebase/red/caproom)
-"BO" = (/obj/structure/closet/crate/wooden/large{icon_closed = "meatball"; icon_state = "meatball"; pixel_x = -2; pixel_y = -2},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/red/trainyard)
-"BR" = (/obj/machinery/light/small/bunker{dir = 8},/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/hallway)
-"BT" = (/obj/structure/reagent_dispensers/watertank{pixel_x = 1; pixel_y = 3},/obj/effect/decal/cleanable/cobweb2{dir = 1},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/room)
-"BU" = (/turf/unsimulated/wall/submarine/doors{dir = 4},/area/train/blue)
-"Cb" = (/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/homebase/red)
-"Cc" = (/obj/machinery/light/caged{dir = 8; pixel_x = 1; pixel_y = 0},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/room)
-"Cd" = (/obj/effect/floor_decal/trench,/obj/structure/trench_wall/innercorners{pixel_x = -32; pixel_y = 31},/obj/structure/trench_wall{dir = 4; pixel_x = -32; pixel_y = 0},/obj/structure/stairs/trenchstairs{dir = 1},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/one)
-"Ce" = (/obj/machinery/light/small/bunker{dir = 8},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"Cg" = (/turf/simulated/floor/dirty/indestructable,/area/warfare/battlefield/capture_point/red/two)
-"Ch" = (/obj/effect/landmark/start{name = "Red Soldier"},/obj/machinery/light/small/bunker{dir = 8},/obj/structure/bed/chair/red,/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"Cj" = (/turf/simulated/wall/perspecticrete,/area/warfare/homebase/blue/largeroom)
-"Cm" = (/obj/structure/trench_wall/innercorners{dir = 1; pixel_x = 32; pixel_y = 31},/obj/structure/table/rack/nosmooth/metal,/obj/item/storage/box/bodybags{pixel_x = 0; pixel_y = -1},/obj/item/storage/box/bodybags{pixel_x = 0; pixel_y = 11},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"Cq" = (/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/room)
-"Cr" = (/obj/machinery/door/airlock/multi_tile/metal/maintenance/red,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/room)
-"Cs" = (/obj/machinery/door/airlock/multi_tile/metal/maintenance{dir = 1; icon_state = "door_closed"; name = "Emergency Medical"},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/hallway)
-"Cu" = (/obj/effect/floor_decal/industrial/warning/dust{dir = 1},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/blue/trainyard)
-"Cy" = (/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section)
-"CA" = (/obj/machinery/body_scanconsole{dir = 4; icon_state = "body_scannerconsole"},/obj/machinery/light{pixel_x = 16},/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/room)
-"CB" = (/obj/structure/table/rack/nosmooth/metal,/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/room)
-"CC" = (/obj/structure/closet/crate/trashcart,/obj/effect/floor_decal/industrial/warning/dust{dir = 1},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/hallway)
-"CG" = (/obj/machinery/light/caged{pixel_x = -34; pixel_y = 0},/obj/effect/floor_decal/trench{dir = 10},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/two)
-"CI" = (/obj/effect/floor_decal/trench{dir = 5},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/one)
-"CO" = (/obj/machinery/light/small/bunker{dir = 8},/turf/simulated/floor/stones,/area/warfare/homebase/blue/largeroom)
-"CQ" = (/obj/structure/bed/chair/red{dir = 1; pixel_x = 0; pixel_y = 11; buckle_pixel_shift = "x=0;y=11"},/turf/simulated/floor/wood,/area/warfare/homebase/red/caproom)
-"CR" = (/obj/structure/window/reinforced{dir = 8; icon_state = "rwindow"},/obj/structure/cargo_pad/blue,/obj/machinery/light/small/bunker{pixel_x = 0; pixel_y = 32},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/room)
-"CT" = (/obj/effect/floor_decal/trench,/obj/machinery/light/caged{pixel_y = -1; dir = 1; pixel_x = 0},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/one)
-"CW" = (/obj/structure/railing/urban{dir = 4},/obj/hammereditor/playerclip,/obj/effect/floor_decal/industrial/warning/dust/corner{dir = 8},/obj/effect/floor_decal/industrial/warning/dust/corner,/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/red/trainyard)
-"CX" = (/obj/structure/closet/crate{pixel_x = 1; pixel_y = 16},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/room)
-"CY" = (/obj/structure/closet/secure_closet/warfare/newver,/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/trench_section/underground)
-"Da" = (/obj/structure/trench_wall/innercorners,/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/indoors)
-"Dc" = (/obj/structure/trench_wall/innercorners,/turf/simulated/mineral{health = 999999},/area/space)
-"Dd" = (/obj/structure/dirt_wall,/obj/machinery/light/caged{dir = 8; pixel_x = 1; pixel_y = 0},/turf/simulated/floor/dirty/indestructable,/area/warfare/battlefield/trench_section)
-"Df" = (/obj/machinery/door/airlock/bunker/blue,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/room)
-"Dq" = (/obj/machinery/kaos/cargo_machine/red,/turf/simulated/floor/stones,/area/warfare/homebase/red/largeroom)
-"Ds" = (/obj/structure/closet/crate/medical,/obj/item/wirecutters,/obj/item/wirecutters,/obj/item/storage/firstaid/regular,/obj/machinery/light/small/bunker{dir = 1},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"Dw" = (/obj/hammereditor/nodraw/deco/shadowpaint{opacity = 1; dir = 4},/obj/structure/train_deco/tracks01,/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/stones,/area/warfare/homebase/red/trainyard)
-"Dy" = (/obj/structure/train_deco/platform{pixel_y = -32; dir = 4; icon_state = "door_closed"; icon = 'icons/obj/doors/Doordoublesecglass1x2BLUE.dmi'},/obj/structure/reagent_dispensers/watertank/blue,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/room)
-"Dz" = (/obj/structure/announcementspeaker/blue{pixel_x = 0; dir = 1},/turf/simulated/open,/area/warfare/battlefield/capture_point/blue/two)
-"DB" = (/obj/structure/trench_wall/sequel{dir = 8},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground)
-"DD" = (/turf/simulated/floor/wood,/area/warfare/homebase/red)
-"DJ" = (/obj/effect/landmark/start{name = "Red Soldier"},/obj/structure/bed/chair/red{dir = 1; pixel_x = 0; pixel_y = 11; buckle_pixel_shift = "x=0;y=11"},/obj/machinery/light/small/bunker{dir = 4},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"DK" = (/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/one)
-"DR" = (/obj/effect/floor_decal/trench{dir = 1},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/one)
-"DT" = (/obj/effect/floor_decal/industrial/warning/dust{dir = 1},/obj/effect/floor_decal/industrial/warning/dust{dir = 4},/obj/effect/floor_decal/industrial/warning/dust/corner{dir = 4},/obj/effect/lighting_dummy/daylight,/obj/effect/landmark/train_marker/teleport/blue,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/blue/trainyard)
-"DW" = (/obj/structure/dirt_wall,/turf/simulated/floor/dirty/fake,/area/warfare/battlefield/capture_point/red/one)
-"DX" = (/obj/effect/landmark/start{name = "Blue Practitioner"},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/stoneroom)
-"Ec" = (/obj/effect/floor_decal/trench,/obj/machinery/light/caged{pixel_y = -1; dir = 1; pixel_x = 0},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/two)
-"Ed" = (/obj/hammereditor/nodraw/deco/shutter_quarter,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/room)
-"Ei" = (/obj/effect/landmark/start{name = "Blue Soldier"},/obj/machinery/light/caged{dir = 4; pixel_x = -19; pixel_y = 0},/obj/structure/bed/chair/blue,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"Ek" = (/obj/item/storage/firstaid/toxin,/obj/item/storage/firstaid/toxin,/obj/item/storage/firstaid/toxin,/obj/item/storage/firstaid/toxin,/obj/structure/table/rack/shelf/red,/obj/structure/table/woodentable/shelf{pixel_y = 26; density = 0},/obj/item/reagent_containers/glass/bottle/antique/slim/chloroform{pixel_x = 10; pixel_y = 32; icon_state = "slim_bl"},/obj/item/reagent_containers/rag{pixel_x = -5; pixel_y = 28},/obj/item/reagent_containers/glass/bottle/antique/slim/chloroform{pixel_x = 1; pixel_y = 31; icon_state = "slim_bl"},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"El" = (/obj/item/flame/candle,/obj/item/device/compass,/obj/item/device/compass,/obj/item/device/compass,/obj/item/device/compass,/obj/item/device/compass,/obj/structure/table/rack/nosmooth/wood/alt{dir = 6},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"Em" = (/obj/structure/train_deco/platform{pixel_y = 3; dir = 4},/obj/hammereditor/playerclip,/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/stones,/area/warfare/homebase/red/trainyard)
-"En" = (/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/blue/trainyard)
-"Eo" = (/obj/structure/cargo_pad/blue,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/largeroom)
-"Eu" = (/obj/effect/landmark/start{name = "Blue Soldier"},/turf/simulated/floor/stones,/area/warfare/homebase/blue/room)
-"EC" = (/obj/effect/darkout_teleporter{id = "SUB_END"; entrance = 0; twoway = 1},/obj/hammereditor/nodraw/deco/shadowpaint{dir = 1},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/space)
-"EI" = (/obj/structure/dirt_wall,/obj/machinery/light/caged{dir = 4; pixel_x = -17; pixel_y = 0},/turf/simulated/floor/dirty/indestructable,/area/warfare/battlefield/trench_section)
-"EM" = (/obj/structure/window/reinforced,/obj/structure/cargo_pad/red,/obj/structure/window/reinforced{dir = 4; icon_state = "rwindow"},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/room)
-"EU" = (/obj/machinery/light{dir = 1; pixel_y = 32},/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/room)
-"EV" = (/obj/machinery/light/small/bunker{pixel_x = 0; pixel_y = 32},/turf/simulated/floor/wood,/area/warfare/homebase/blue/caproom)
-"EW" = (/turf/simulated/floor/dirty/indestructable,/area/train/red)
-"Fb" = (/obj/machinery/computer/operating{icon_state = "console"},/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/room)
-"Fc" = (/turf/simulated/floor/dirty/indestructable,/area/train/blue)
-"Ff" = (/obj/effect/lighting_dummy/daylight,/turf/simulated/wall/perspecticrete,/area/warfare/homebase/blue/trainyard)
-"Fg" = (/obj/machinery/sleeper,/obj/structure/trench_wall/innercorners{dir = 4; pixel_x = -32; pixel_y = -32},/obj/machinery/light/caged{dir = 1; pixel_y = -1},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"Fi" = (/obj/hammereditor/nodraw/deco/shadowpaint{opacity = 1; dir = 8},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/stones,/area/warfare/homebase/blue/trainyard)
-"Fj" = (/turf/simulated/wall/perspectisub,/area/train/blue)
-"Fk" = (/obj/structure/trench_wall{dir = 4},/obj/hammereditor/nodraw/deco/shadowpaint{dir = 1},/turf/simulated/mineral{health = 999999},/area/space)
-"Fp" = (/obj/structure/trench_wall{dir = 1; pixel_y = -32},/obj/item/autopsy_scanner{pixel_x = -4; pixel_y = -1},/obj/structure/table/rack/nosmooth/metal,/obj/item/reagent_containers/spray/cleaner/warfare/red{pixel_x = 6; pixel_y = 1},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"Fq" = (/obj/structure/trench_wall{dir = 4},/obj/structure/trench_wall/sequel{dir = 4},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/indoors)
-"Fr" = (/turf/simulated/wall/perspecticrete,/area/warfare/homebase/red/room)
-"Ft" = (/obj/effect/landmark/start/bluecoats,/obj/machinery/light/small{dir = 1; pixel_y = 37},/obj/structure/bed/chair/red,/turf/simulated/floor/ert/metal01,/area/train/blue)
-"Fw" = (/obj/structure/toilet{dir = 4; icon_state = "toilet00"},/obj/machinery/light/caged{pixel_y = 30; pixel_x = 0},/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/room)
-"Fx" = (/obj/structure/trench_wall/sequel{dir = 8},/turf/simulated/mineral{health = 999999},/area/space)
-"Fy" = (/obj/structure/trench_wall/innercorners,/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/bunker)
-"FC" = (/obj/structure/trench_wall{dir = 1},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/indoors)
-"FE" = (/obj/effect/floor_decal/trench{dir = 6},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/two)
-"FL" = (/obj/structure/closet/secure_closet/warfare/newver,/obj/item/crowbar/red,/obj/item/crowbar/red,/obj/item/crowbar/red,/obj/structure/banner/red/small{pixel_y = 32},/turf/simulated/floor/stones,/area/warfare/homebase/red/largeroom)
-"FP" = (/obj/machinery/door/airlock/bunker/red,/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/room)
-"FQ" = (/obj/effect/landmark/start/bluecoats,/obj/structure/bed/chair/red,/turf/simulated/floor/ert/metal01,/area/train/blue)
-"FR" = (/obj/effect/floor_decal/stones,/turf/simulated/floor/dirty/indestructable,/area/warfare/battlefield/trench_section)
-"FS" = (/obj/machinery/door/unpowered/simple/wood/captain{desc = "There are constant rumours throughout the front that something is happening beneath it. They believe that the battle above is merely just a cover for something much more severe."; name = "Mysterious Door"},/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
-"FT" = (/obj/machinery/door/airlock/multi_tile/metal/maintenance/red,/obj/effect/decal/cleanable/ash,/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/hallway)
-"FW" = (/obj/machinery/door/airlock/multi_tile/metal/maintenance/blue,/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/hallway)
-"FX" = (/obj/structure/table/rack/holorack,/turf/simulated/wall/perspecticrete,/area/warfare/homebase/blue/largeroom)
-"FY" = (/obj/effect/decal/cleanable/blood,/turf/simulated/floor/urban/cinder,/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
-"FZ" = (/obj/structure/trench_wall/innercorners{dir = 4; pixel_x = -32},/obj/structure/trench_wall/innercorners{dir = 8},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/space)
-"Gd" = (/obj/structure/closet/crate/wooden{pixel_x = 4; pixel_y = 12},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/red/trainyard)
-"Gf" = (/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/cinder,/area/warfare/battlefield/capture_point/red/two)
-"Gg" = (/obj/structure/curtain/medical{color = "#b8dddddd"},/obj/structure/table/rack/nosmooth/metal,/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/stoneroom)
-"Gh" = (/obj/structure/warfare_itemeater/blue{pixel_y = 32},/turf/simulated/floor/dirty/indestructable,/area/warfare/homebase/blue)
-"Gn" = (/obj/structure/bed/roller,/obj/machinery/light{dir = 4},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/stoneroom)
-"Go" = (/obj/structure/table/rack/nosmooth/wood,/obj/item/device/compass,/turf/simulated/floor/stones,/area/warfare/homebase/blue/room)
-"Gs" = (/obj/structure/soldiercryo/special/red,/obj/machinery/light/small/bunker{dir = 4},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/room)
-"Gu" = (/turf/simulated/floor/concrete/random,/area/space)
-"Gv" = (/obj/structure/train_deco/tracks01,/turf/space,/area/warfare/homebase/blue/trainyard)
-"GA" = (/obj/item/device/compass,/obj/item/device/compass,/obj/item/device/compass,/obj/structure/table/rack/nosmooth/wood/alt{dir = 6},/obj/item/flame/candle/blue,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"GD" = (/obj/structure/window/reinforced{dir = 8; icon_state = "rwindow"},/obj/structure/window/reinforced,/obj/structure/cargo_pad/blue,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/room)
-"GH" = (/obj/structure/table/rack/nosmooth/wood/alt{dir = 10},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"GO" = (/obj/machinery/light/small/bunker{pixel_x = 0; pixel_y = 32},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"GR" = (/obj/effect/decal/cleanable/cobweb,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/hallway)
-"GT" = (/obj/structure/sign/warning/lethal_turrets,/obj/hammereditor/nodraw,/turf/simulated/wall/perspecticrete,/area/warfare/homebase/red/hallway)
-"GX" = (/obj/structure/trench_wall/innercorners{dir = 4},/obj/structure/trench_wall{dir = 8},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/indoors)
-"Ha" = (/obj/structure/railing/urban{dir = 4},/obj/effect/lighting_dummy/daylight,/obj/hammereditor/playerclip,/obj/effect/floor_decal/industrial/warning/dust/corner{dir = 1},/obj/effect/floor_decal/industrial/warning/dust/corner{dir = 4},/turf/simulated/floor/urban/concrete,/area/warfare/homebase/blue/trainyard)
-"Hc" = (/obj/structure/announcementspeaker/blue{pixel_y = 0; dir = 4},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"He" = (/obj/effect/decal/cleanable/blood,/obj/machinery/light/small/bunker{dir = 8},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"Hf" = (/obj/item/flame/candle,/obj/item/storage/fancy/cigarettes/carcinomas,/obj/item/ammo_box/rifle,/obj/structure/table/rack/nosmooth/wood/alt{dir = 5},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"Hj" = (/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/room)
-"Hm" = (/obj/effect/landmark/start{name = "Blue Soldier"},/obj/machinery/light/caged{dir = 4; pixel_x = -19; pixel_y = 0},/obj/structure/bed/chair/blue{dir = 1; pixel_x = 0; pixel_y = 11; buckle_pixel_shift = "x=0;y=11"},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"Ho" = (/mob/living/simple_animal/hostile/retaliate/rat,/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/two)
-"Hq" = (/obj/structure/trench_wall/innercorners{dir = 1},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground)
-"Hw" = (/obj/structure/train_deco/sides,/obj/hammereditor/playerclip,/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/stones,/area/warfare/homebase/red/trainyard)
-"Hy" = (/turf/simulated/floor/urban/cinder,/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
-"HE" = (/obj/structure/reagent_dispensers/watertank/blue,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/room)
-"HH" = (/obj/structure/stairs/trenchstairs{dir = 1},/obj/structure/announcementspeaker/red{pixel_y = 32},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/one)
-"HL" = (/obj/machinery/body_scanconsole{dir = 4; icon_state = "body_scannerconsole"},/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"HN" = (/obj/structure/closet/crate,/obj/random/canned_food/blue,/obj/random/canned_food/blue,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"HO" = (/obj/structure/trench_wall{dir = 8; pixel_x = 32; pixel_y = 0},/obj/structure/table/rack/shelf/red,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/room)
-"HQ" = (/obj/effect/floor_decal/trench{dir = 1},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/two)
-"HS" = (/obj/structure/closet/crate/wooden{pixel_x = 4; pixel_y = -8},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/blue/trainyard)
-"HT" = (/obj/item/storage/fancy/cigarettes/jerichos,/obj/item/flame/candle,/obj/item/flame/lighter/random,/obj/structure/table/rack/nosmooth/wood/alt,/obj/structure/announcementspeaker/red{pixel_x = 0; dir = 4},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"HU" = (/obj/machinery/light/caged{pixel_y = -1; dir = 1; pixel_x = 16},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"Ic" = (/obj/machinery/light,/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"Id" = (/obj/machinery/light/caged{dir = 8; pixel_x = 10; pixel_y = 13},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/trench_section/underground)
-"Ie" = (/obj/hammereditor/nodraw/deco/shadowpaint{dir = 1},/turf/simulated/floor/concrete/random,/area/space)
-"If" = (/obj/machinery/kaos/cargo_machine/blue,/turf/simulated/floor/wood,/area/warfare/homebase/blue/caproom)
-"Ig" = (/obj/effect/floor_decal/trench{dir = 4},/obj/machinery/light/caged{pixel_y = -1; dir = 1; pixel_x = 0},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/two)
-"Ih" = (/obj/machinery/kaos/cargo_machine/blue,/turf/simulated/floor/stones,/area/warfare/homebase/blue/largeroom)
-"Ik" = (/obj/structure/trench_wall{dir = 6},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/bunker)
-"Ip" = (/obj/structure/toilet{dir = 8; icon_state = "toilet00"},/obj/machinery/light/caged{pixel_y = 30; pixel_x = 0},/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/room)
-"It" = (/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/room)
-"Iw" = (/obj/structure/closet/crate/wooden/large{icon_closed = "meatball"; icon_state = "meatball"; pixel_x = 0; pixel_y = -15},/obj/effect/floor_decal/industrial/warning/dust{dir = 1},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/blue/trainyard)
-"Iy" = (/obj/structure/trench_wall/innercorners{dir = 4},/obj/structure/trench_wall/innercorners{dir = 8; pixel_x = 32},/turf/simulated/mineral{health = 999999},/area/space)
-"Iz" = (/obj/structure/warfare_itemeater/red,/turf/simulated/wall/perspecticrete,/area/warfare/homebase/red/largeroom)
-"IF" = (/obj/structure/poster/red,/obj/hammereditor/nodraw,/turf/simulated/wall/perspecticrete,/area/warfare/homebase/red/hallway)
-"IK" = (/obj/hammereditor/nodraw/deco/bars,/turf/simulated/floor/dirty/indestructable,/area/space)
-"IN" = (/obj/effect/landmark/start{name = "Red Soldier"},/obj/structure/bed/chair/red{dir = 4; pixel_x = 6; pixel_y = 0; buckle_pixel_shift = "x=6;y=0"},/obj/machinery/light/small/bunker{dir = 8},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"IP" = (/obj/effect/floor_decal/train_deco/stripes{dir = 4; pixel_y = 11},/obj/effect/darkout_teleporter/bluecoats,/obj/effect/floor_decal/industrial/warning/dust,/obj/effect/landmark/train_marker/teleport/red,/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/red/trainyard)
-"IQ" = (/obj/structure/trench_wall{dir = 10},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/indoors)
-"IR" = (/obj/structure/dirt_wall,/obj/structure/announcementspeaker/red{pixel_x = 0; dir = 4},/turf/simulated/floor/dirty/indestructable,/area/warfare/battlefield/trench_section)
-"IV" = (/obj/structure/sign/medholo,/turf/simulated/wall/perspecticrete,/area/warfare/homebase/blue/stoneroom)
-"IW" = (/obj/machinery/light/small/bunker{pixel_x = 0; pixel_y = 32},/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/stones,/area/warfare/homebase/red/room)
-"IX" = (/obj/effect/landmark/start{name = "Red Soldier"},/obj/structure/bed/chair/red,/obj/machinery/light/small/bunker{dir = 4},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"IZ" = (/obj/effect/floor_decal/trench{dir = 9},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/one)
-"Jb" = (/obj/hammereditor/nodraw/deco/shadowpaint{opacity = 1; dir = 8},/obj/structure/train_deco/tracks01,/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/stones,/area/warfare/homebase/red/trainyard)
-"Jc" = (/obj/machinery/light{dir = 1; pixel_y = 32},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"Jd" = (/obj/effect/landmark/start{name = "Red Scavenger"},/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/stones,/area/warfare/homebase/red/room)
-"Je" = (/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/room)
-"Jj" = (/turf/space,/area/space)
-"Jm" = (/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/hallway)
-"Jv" = (/obj/structure/announcementspeaker/red{id = "Bluecoats"},/turf/simulated/wall/perspecticrete,/area/warfare/homebase/blue/room)
-"Jy" = (/obj/effect/landmark/start{name = "Blue Soldier"},/obj/machinery/light/caged{pixel_y = 30; pixel_x = -16},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"JG" = (/obj/structure/trench_wall{dir = 10},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/blue/two)
-"JH" = (/obj/machinery/light/caged{pixel_x = 34; pixel_y = 0},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/one)
-"JK" = (/obj/structure/sign/neon/armory{pixel_y = 32; color = "FFFF00"},/obj/effect/floor_decal/industrial/direction{dir = 4},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/hallway)
-"JL" = (/obj/effect/landmark/start{name = "Red Soldier"},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"JR" = (/obj/effect/decal/cleanable/cobweb2{dir = 8},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/hallway)
-"JT" = (/obj/structure/announcementspeaker/blue{pixel_x = 0; dir = 1},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/trench_section/underground)
-"JU" = (/obj/structure/trench_wall{dir = 1},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/room)
-"JX" = (/obj/effect/landmark/start{name = "Red Soldier"},/obj/structure/announcementspeaker/red{pixel_y = 32},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"Kg" = (/obj/effect/floor_decal/trench{dir = 8},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/one)
-"Kh" = (/obj/structure/window/reinforced{dir = 8; icon_state = "rwindow"},/obj/structure/window/reinforced,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/room)
-"Kk" = (/obj/machinery/light{pixel_x = 16},/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/room)
-"Km" = (/obj/hammereditor/nodraw,/turf/simulated/wall/perspecticrete,/area/warfare/homebase/red/largeroom)
-"Ku" = (/obj/structure/trench_wall{dir = 4},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/red/one)
-"Kv" = (/obj/structure/closet/secure_closet/warfare/practicioner,/obj/item/clothing/suit/surgeon_apron,/obj/item/clothing/suit/surgeon_apron,/obj/item/clothing/gloves/latex,/obj/item/clothing/gloves/latex,/obj/item/clothing/mask/surgical,/obj/item/clothing/mask/surgical,/obj/item/storage/backpack/satchel/warfare/prac/blue,/obj/structure/announcementspeaker/blue{pixel_x = 0; pixel_y = 32},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"Kx" = (/obj/machinery/light/small/bunker{dir = 8; pixel_x = 0; pixel_y = 15},/turf/simulated/floor/stones,/area/warfare/homebase/red/largeroom)
-"Ky" = (/obj/effect/landmark/start,/turf/simulated/mineral{health = 999999},/area/warfare/homebase/red)
-"KB" = (/obj/effect/landmark{name = "tdome1"},/turf/simulated/mineral{health = 999999},/area/warfare/homebase/red)
-"KH" = (/obj/structure/trench_wall/innercorners{dir = 8; pixel_x = 32; pixel_y = -32},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"KI" = (/obj/effect/floor_decal/stones,/turf/simulated/floor/dirty/indestructable,/area/warfare/battlefield/capture_point/blue/one)
-"KO" = (/turf/simulated/wall/perspecticrete,/area/warfare/homebase/blue/caproom)
-"KU" = (/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red)
-"KV" = (/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/largeroom)
-"KY" = (/obj/item/device/flashlight/lantern{on = 1; pixel_x = -6; pixel_y = -10},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/trench_section/underground)
-"Lc" = (/obj/effect/floor_decal/stones,/turf/simulated/floor/dirty/indestructable,/area/warfare/battlefield/capture_point/blue/two)
-"Li" = (/obj/structure/trench_wall/innercorners{dir = 4},/obj/structure/trench_wall/innercorners{dir = 8; pixel_x = 32},/obj/structure/sign/warning/secure_area{icon_state = "securearea2"},/obj/hammereditor/nodraw,/turf/simulated/wall/perspecticrete,/area/warfare/homebase/red/hallway)
-"Ll" = (/turf/simulated/wall/perspectisub,/area/train/red)
-"Lm" = (/obj/machinery/computer/operating{icon_state = "console"},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"Ln" = (/obj/structure/trench_wall{dir = 10},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground)
-"Lq" = (/obj/structure/warfare/thehatch{dir = 4},/turf/simulated/wall/perspecticrete,/area/warfare/homebase/blue/room)
-"Ls" = (/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/stoneroom)
-"Lt" = (/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/stoneroom)
-"Lz" = (/obj/structure/defensive_barrier{pixel_y = -4; secured = 1},/obj/hammereditor/nodraw,/turf/simulated/wall/perspecticrete,/area/warfare/battlefield/trench_section/underground)
-"LD" = (/obj/machinery/light/small/bunker{dir = 8},/turf/simulated/floor/stones,/area/warfare/homebase/blue/room)
-"LE" = (/obj/machinery/light/small/bunker{pixel_x = 0; pixel_y = 32},/obj/machinery/camera{dir = 4; pixel_x = 2; pixel_y = 0},/turf/simulated/floor/wood,/area/warfare/homebase/red/caproom)
-"LI" = (/obj/machinery/light/caged{pixel_y = 30; pixel_x = 0},/obj/structure/trench_wall{dir = 4; pixel_x = -32; pixel_y = 0},/obj/structure/table/rack/shelf/red,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/room)
-"LK" = (/obj/structure/trench_wall{dir = 1},/turf/simulated/mineral{health = 999999},/area/space)
-"LT" = (/obj/effect/floor_decal/trench{dir = 4},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/one)
-"LV" = (/obj/structure/lattice,/obj/machinery/light/caged{dir = 8; pixel_x = 10; pixel_y = 0},/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/underground)
-"LW" = (/obj/item/device/flashlight/lantern{on = 1; pixel_x = -13; pixel_y = -6},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/space)
-"LX" = (/obj/effect/floor_decal/trench,/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/two)
-"Mb" = (/obj/machinery/light/caged{pixel_y = 30; pixel_x = 0},/obj/structure/closet/crate/grenade,/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/room)
-"Mf" = (/obj/random/canned_food/red,/obj/random/canned_food/red,/obj/random/canned_food/red,/obj/structure/table/rack/shelf/red,/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/room)
-"Mg" = (/obj/effect/floor_decal/industrial/warning/dust{dir = 1},/obj/effect/floor_decal/industrial/warning/dust{dir = 8},/obj/effect/floor_decal/industrial/warning/dust/corner{dir = 1},/obj/structure/train_deco/platform{pixel_y = 16},/obj/effect/lighting_dummy/daylight,/obj/effect/landmark/train_marker/teleport/blue,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/blue/trainyard)
-"Ml" = (/obj/machinery/light/caged{pixel_y = -14; dir = 1; pixel_x = 0},/obj/structure/trench_wall{dir = 4; pixel_x = -32; pixel_y = 0},/obj/structure/trench_wall/innercorners{dir = 4; pixel_x = -32; pixel_y = -32},/obj/structure/trench_wall/sequel{dir = 5; pixel_x = 0; pixel_y = -32},/obj/structure/closet/crate/club,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/room)
-"Mq" = (/obj/structure/sign/medholo,/turf/simulated/wall/perspecticrete,/area/warfare/homebase/red/stoneroom)
-"Mv" = (/obj/structure/warfare/thehatch{dir = 4},/turf/simulated/wall/perspecticrete,/area/warfare/homebase/red/room)
-"MB" = (/obj/item/storage/firstaid/surgery,/obj/structure/table/rack/nosmooth/metal,/obj/item/reagent_containers/spray/cleaner/warfare{pixel_x = 4; pixel_y = 18},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"MG" = (/obj/structure/closet/crate,/obj/random/canned_food/blue,/obj/random/canned_food/blue,/obj/random/canned_food/blue,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"MM" = (/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/trench_section/underground)
-"MP" = (/obj/hammereditor/nodraw/deco/shadowpaint{opacity = 1; dir = 4},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/stones,/area/warfare/homebase/blue/trainyard)
-"MS" = (/obj/effect/decal/cleanable/blood,/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/room)
-"MV" = (/obj/structure/defensive_barrier{secured = 1; dir = 8; pixel_x = 2; pixel_y = 3},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/space)
-"MW" = (/obj/machinery/light/small/bunker{dir = 1},/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/stoneroom)
-"MZ" = (/obj/structure/trench_wall/sequel{dir = 8},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/blue/two)
-"Nb" = (/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/homebase/red/hallway)
-"Nc" = (/obj/effect/floor_decal/trench{dir = 10},/obj/structure/stairs/trenchstairs,/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/two)
-"Nd" = (/obj/structure/closet/crate/wooden{pixel_x = -3; pixel_y = 1},/obj/structure/closet/crate/wooden{pixel_x = -3; pixel_y = 12},/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
-"Nf" = (/obj/structure/train_deco/tracks01,/obj/hammereditor/nodraw/deco/shadowpaint{opacity = 1; dir = 8},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/stones,/area/warfare/homebase/blue/trainyard)
-"Ng" = (/obj/structure/table/rack/nosmooth/metal,/obj/item/paper/crumpled{info = "///// ///// ///// //"; pixel_x = -1; pixel_y = 3; contents = "///// ///// ///// //"; name = "Tally"},/obj/item/storage/box/bodybags,/obj/item/pen/red{pixel_x = -7; pixel_y = 8},/obj/machinery/light{dir = 1; pixel_y = 32},/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/room)
-"No" = (/obj/effect/landmark/start{name = "Blue Squad Leader"},/obj/machinery/light/small/bunker{dir = 8},/turf/simulated/floor/stones,/area/warfare/homebase/blue/room)
-"Nq" = (/turf/simulated/mineral{health = 999999},/area/warfare/homebase/red/stoneroom)
-"Nr" = (/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/bunker)
-"Nt" = (/obj/structure/trench_wall{dir = 10},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/blue/one)
-"Nv" = (/obj/structure/trench_wall/sequel{dir = 8},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/red/one)
-"Nw" = (/obj/structure/train_deco/sides,/obj/effect/lighting_dummy/daylight,/obj/hammereditor/playerclip,/turf/simulated/floor/stones,/area/warfare/homebase/blue/trainyard)
-"Nz" = (/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"NA" = (/obj/machinery/light/small/bunker{dir = 4},/obj/structure/announcementspeaker/blue{pixel_y = 0; dir = 8},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"ND" = (/obj/structure/table/rack/shelf/red,/turf/simulated/floor/stones,/area/warfare/homebase/red/largeroom)
-"NG" = (/obj/structure/banner/red/small{pixel_y = 32},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/two)
-"NH" = (/turf/simulated/mineral{health = 999999},/area/warfare/homebase/red/trainyard)
-"NI" = (/obj/effect/landmark/start{name = "Red Soldier"},/obj/structure/bed/chair/red{dir = 1; pixel_x = 0; pixel_y = 11; buckle_pixel_shift = "x=0;y=11"},/obj/machinery/light/caged{pixel_y = -1; dir = 1; pixel_x = -16},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"NJ" = (/obj/structure/announcementspeaker/red{pixel_x = 0; dir = 1},/turf/simulated/floor/dirty/indestructable,/area/warfare/homebase/red)
-"NM" = (/obj/machinery/kaos/cargo_machine/red,/turf/simulated/floor/wood,/area/warfare/homebase/red/caproom)
-"NN" = (/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/indoors)
-"NO" = (/obj/hammereditor/nodraw/deco/shutter_half{dir = 4},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/room)
-"NP" = (/obj/structure/trench_wall,/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/indoors)
-"NQ" = (/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/room)
-"NT" = (/obj/structure/toilet{dir = 4; icon_state = "toilet00"},/obj/structure/trench_wall{dir = 4; pixel_x = -32; pixel_y = 0},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/room)
-"NV" = (/obj/structure/toilet{dir = 8; icon_state = "toilet00"},/turf/simulated/floor/stones,/area/warfare/homebase/blue/room)
-"NW" = (/obj/structure/trench_wall/innercorners{dir = 4},/obj/structure/trench_wall/innercorners{dir = 8; pixel_x = 32},/turf/simulated/wall/perspecticrete,/area/warfare/homebase/red/hallway)
-"NX" = (/obj/structure/trench_wall,/turf/simulated/mineral{health = 999999},/area/space)
-"NZ" = (/turf/simulated/mineral{health = 999999},/area/warfare/homebase/blue/div)
-"Oa" = (/obj/machinery/light/small/bunker{pixel_x = 0; pixel_y = 32},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"Ob" = (/obj/structure/trench_wall{dir = 4},/obj/structure/trench_wall{dir = 6},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/indoors)
-"Ol" = (/obj/structure/banner/red/small{pixel_y = 32},/obj/effect/floor_decal/trench{dir = 4},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/two)
-"Op" = (/obj/effect/landmark/start{name = "Red Soldier"},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/hallway)
-"Os" = (/obj/hammereditor/nodraw/deco/shadowpaint{opacity = 1; dir = 4},/turf/simulated/wall/perspecticrete,/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
-"Ot" = (/turf/simulated/wall/perspecticrete,/area/warfare/homebase/red/caproom)
-"Ow" = (/obj/structure/announcementspeaker/red{pixel_x = 0; dir = 4},/turf/simulated/floor/dirty/indestructable,/area/warfare/battlefield/trench_section)
-"Ox" = (/obj/item/storage/firstaid/fire,/obj/item/storage/firstaid/fire,/obj/item/storage/firstaid/fire,/obj/item/storage/firstaid/fire,/obj/structure/table/rack/shelf/red,/obj/machinery/light{dir = 8},/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/room)
-"Oy" = (/obj/structure/trench_wall/innercorners{dir = 1},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/blue/two)
-"OA" = (/obj/random/canned_food/red,/obj/random/canned_food/red,/obj/structure/table/rack/shelf/red,/obj/random/canned_food/red,/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/room)
-"OB" = (/obj/structure/table/woodentable/shelf{pixel_y = 13},/obj/item/device/boombox/stationary{pixel_x = 1; pixel_y = 18},/turf/simulated/floor/stones,/area/warfare/homebase/blue/largeroom)
-"OC" = (/obj/effect/lighting_dummy/daylight,/obj/structure/train_deco/tracks01,/turf/simulated/floor/stones,/area/warfare/homebase/blue/trainyard)
-"OD" = (/obj/structure/trench_wall{dir = 4},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/indoors)
-"OE" = (/obj/machinery/light/caged{pixel_y = 30; pixel_x = 0},/obj/effect/floor_decal/trench,/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/one)
-"OH" = (/obj/structure/train_deco/platform{pixel_y = 3; dir = 1},/obj/hammereditor/playerclip,/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/stones,/area/warfare/homebase/red/trainyard)
-"OJ" = (/obj/item/device/compass,/obj/structure/table/rack/nosmooth/wood,/turf/simulated/floor/stones,/area/warfare/homebase/red/room)
-"OK" = (/obj/hammereditor/nodraw/deco/shadowpaint,/obj/hammereditor/nodraw/deco/shadowpaint{opacity = 1; dir = 4},/turf/simulated/floor/stones,/area/warfare/homebase/red/trainyard)
-"OL" = (/obj/machinery/light/small/bunker{dir = 1},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/hallway)
-"OQ" = (/obj/structure/closet/crate{pixel_x = 0; pixel_y = -1},/obj/structure/closet/crate{pixel_x = 3; pixel_y = 20},/obj/effect/decal/cleanable/cobweb2{dir = 1},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/room)
-"OR" = (/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/room)
-"OS" = (/obj/structure/trench_wall{dir = 8},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/red/one)
-"OU" = (/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/stoneroom)
-"OX" = (/obj/machinery/light{dir = 4},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/hallway)
-"OY" = (/obj/machinery/light/caged{dir = 4; pixel_x = -1; pixel_y = 0},/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"Pd" = (/obj/structure/table/rack/shelf/red,/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"Pg" = (/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/room)
-"Pi" = (/obj/machinery/light/small/bunker{dir = 1},/obj/structure/announcementspeaker/red{pixel_x = 0; dir = 8},/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/hallway)
-"Pj" = (/obj/hammereditor/nodraw,/turf/simulated/floor/ert/metal01,/area/train/blue)
-"Pk" = (/obj/structure/curtain/tarp{dir = 4},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"Pq" = (/obj/effect/floor_decal/industrial/warning/dust,/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/red/trainyard)
-"Pt" = (/obj/effect/landmark/start{name = "Red Squad Leader"},/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/stones,/area/warfare/homebase/red/room)
-"Pw" = (/obj/machinery/light/caged{pixel_y = 30; pixel_x = 0},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/two)
-"Px" = (/obj/structure/sign/neon/cargo,/turf/simulated/wall/perspecticrete,/area/warfare/homebase/red/largeroom)
-"Py" = (/obj/effect/landmark/start{name = "Red Engineer"},/obj/machinery/light/small/bunker{dir = 1},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"Pz" = (/obj/structure/closet/crate{pixel_x = -6; pixel_y = 13},/obj/structure/train_deco/platform{pixel_y = 32; dir = 4; icon_state = "door_closed"; icon = 'icons/obj/doors/Doordoublesecglass1x2BLUE.dmi'},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/room)
-"PC" = (/obj/machinery/light/small/bunker{dir = 1},/obj/item/storage/toggle/envelope{pixel_x = 0; pixel_y = 5},/obj/item/storage/toggle/envelope{pixel_x = -8; pixel_y = 5},/obj/item/storage/toggle/envelope{pixel_x = 8; pixel_y = 5},/obj/item/storage/toggle/envelope{pixel_x = -8; pixel_y = 3},/obj/item/storage/toggle/envelope{pixel_x = 0; pixel_y = 3},/obj/item/storage/toggle/envelope{pixel_x = 8; pixel_y = 3},/obj/item/storage/toggle/envelope{pixel_x = -8; pixel_y = 1},/obj/item/storage/toggle/envelope{pixel_x = 0; pixel_y = 1},/obj/item/storage/toggle/envelope{pixel_x = 8; pixel_y = 1},/obj/structure/table/nosmooth/capnew{pixel_y = -4; dir = 8},/obj/structure/table/nosmooth/capnew{pixel_y = 28; dir = 9; pixel_x = 0},/obj/item/waxstamp{pixel_x = -9; pixel_y = 12},/obj/item/flame/candle{pixel_x = -10; pixel_y = 19},/obj/item/flame/candle{pixel_x = -6; pixel_y = 19},/obj/item/flame/candle{pixel_x = -8; pixel_y = 19},/obj/item/storage/box/matches{pixel_x = 0; pixel_y = 17},/obj/structure/window/reinforced{pixel_x = 0; pixel_y = 7},/obj/machinery/light{dir = 8},/turf/simulated/floor/stones,/area/warfare/homebase/red/largeroom)
-"PH" = (/obj/hammereditor/nodraw/deco/bars,/obj/hammereditor/nodraw/deco/bars{pixel_y = 10},/obj/hammereditor/nodraw,/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/space)
-"PI" = (/obj/structure/banner/red/small{pixel_y = 32},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"PJ" = (/obj/sound_emitter/periodic/env_leak,/obj/effect/landmark/start{name = "Red Soldier"},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/largeroom)
-"PS" = (/obj/structure/closet/secure_closet/medical1/warfare,/obj/item/clothing/suit/surgeon_apron,/obj/item/clothing/suit/surgeon_apron,/obj/item/clothing/suit/surgeon_apron,/obj/item/clothing/suit/surgeon_apron,/obj/item/storage/backpack/satchel/warfare/prac/blue,/obj/item/storage/backpack/satchel/warfare/prac/blue,/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"PV" = (/obj/machinery/sleeper{dir = 4; icon_state = "sleeper_0"},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"PZ" = (/obj/structure/warfare/thehatch{dir = 4},/obj/structure/trench_wall{dir = 9; pixel_y = 0; layer = 28},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/indoors)
-"Qa" = (/obj/machinery/light/caged{pixel_y = 30; pixel_x = 0},/turf/simulated/floor/dirty/indestructable,/area/warfare/battlefield/trench_section)
-"Qb" = (/obj/machinery/light{dir = 8},/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/hallway)
-"Qc" = (/obj/machinery/light/caged{pixel_y = -1; dir = 1; pixel_x = 0},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/one)
-"Qh" = (/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/room)
-"Qj" = (/obj/effect/landmark/start{name = "Blue Soldier"},/obj/structure/announcementspeaker/blue{pixel_x = 0; dir = 1},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"Qk" = (/obj/effect/decal/cleanable/cobweb,/obj/effect/structure{anchored = 1; icon = 'icons/obj/modular_console.dmi'; icon_state = "console"; pixel_x = 6; pixel_y = 3; layer = 222},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/room)
-"Ql" = (/obj/item/flame/candle,/obj/item/storage/box/matches,/obj/structure/table/rack/nosmooth/wood/alt{dir = 4},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"Qm" = (/obj/effect/floor_decal/trench{dir = 6},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/one)
-"Qt" = (/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red)
-"Qu" = (/obj/item/device/compass,/obj/item/device/compass,/obj/item/device/compass,/obj/item/device/compass,/obj/item/device/compass,/obj/structure/table/rack/nosmooth/wood/alt{dir = 6},/obj/item/flame/candle/blue,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"Qx" = (/obj/hammereditor/playerclip,/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/stones,/area/warfare/homebase/red/trainyard)
-"Qy" = (/obj/effect/floor_decal/trench{dir = 10},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/two)
-"QA" = (/obj/machinery/light/small,/turf/simulated/floor/urban/cinder,/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
-"QB" = (/obj/effect/structure{anchored = 1; icon = 'icons/obj/modular_console.dmi'; icon_state = "console"; layer = 222},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"QD" = (/obj/structure/dirt_wall,/obj/structure/announcementspeaker/blue{pixel_x = 0; pixel_y = 32},/turf/simulated/floor/dirty/indestructable,/area/warfare/battlefield/trench_section/hallway)
-"QE" = (/obj/structure/warfare_itemeater/red{pixel_y = 28},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/trench_section/underground)
-"QF" = (/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/two)
-"QL" = (/obj/effect/darkout_teleporter/bluecoats,/turf/unsimulated/wall/submarine/doors,/area/train/blue)
-"QN" = (/obj/structure/railing/urban{dir = 4},/obj/effect/lighting_dummy/daylight,/obj/effect/floor_decal/industrial/warning/dust/corner{dir = 4},/obj/effect/floor_decal/industrial/warning/dust/corner{dir = 1},/turf/simulated/floor/urban/concrete,/area/warfare/homebase/blue/trainyard)
-"QO" = (/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/cinder,/area/warfare/battlefield/capture_point/blue/two)
-"QQ" = (/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/hallway)
-"QR" = (/obj/machinery/light/small/bunker{pixel_x = 0; pixel_y = 32},/turf/simulated/floor/wood,/area/warfare/homebase/red/caproom)
-"QS" = (/obj/machinery/light/caged{dir = 8; pixel_x = 10; pixel_y = 0},/obj/effect/floor_decal/trench{dir = 5},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/one)
-"QU" = (/obj/effect/floor_decal/industrial/warning/dust{dir = 4},/obj/effect/lighting_dummy/daylight,/obj/effect/landmark/train_marker/teleport/red,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/red/trainyard)
-"QW" = (/obj/structure/closet/crate/wooden{pixel_x = 4; pixel_y = -8},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/red/trainyard)
-"QZ" = (/obj/machinery/vending/medical{req_access = newlist()},/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/room)
-"Rb" = (/obj/hammereditor/nodraw,/turf/simulated/wall/perspecticrete,/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
-"Rc" = (/obj/structure/stairs/trenchstairs{dir = 1},/obj/structure/announcementspeaker/blue{pixel_y = 32},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/two)
-"Rd" = (/obj/structure/banner/blue/small{pixel_y = 32},/obj/machinery/light/caged{pixel_y = 30; pixel_x = 0},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"Rg" = (/obj/machinery/light/small/bunker{dir = 4},/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/hallway)
-"Ri" = (/obj/structure/table/rack/holorack,/obj/structure/closet/crate,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/room)
-"Rj" = (/turf/simulated/mineral{health = 999999},/area/warfare/homebase/blue/trainyard)
-"Rk" = (/obj/item/flame/candle,/obj/item/flame/lighter/random,/obj/structure/table/rack/nosmooth/wood/alt{dir = 4},/obj/item/flame/candle/blue,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"Rl" = (/obj/hammereditor/nodraw,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/stoneroom)
-"Rn" = (/obj/structure/window/reinforced{dir = 8; icon_state = "rwindow"},/obj/structure/window/reinforced,/obj/structure/cargo_pad/red,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/room)
-"Rr" = (/obj/effect/lighting_dummy/daylight,/obj/structure/train_deco/platform{pixel_y = -32; dir = 4; icon_state = "door_closed"; icon = 'icons/obj/doors/Doordoublesecglass1x2BLUE.dmi'},/turf/simulated/floor/urban/concrete,/area/warfare/homebase/blue/trainyard)
-"Rv" = (/obj/item/storage/firstaid/adv,/obj/item/storage/firstaid/adv,/obj/item/storage/firstaid/adv,/obj/item/storage/firstaid/adv,/obj/structure/table/rack/shelf/red,/obj/machinery/light{dir = 8},/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/room)
-"Ry" = (/obj/machinery/camera{dir = 4; pixel_x = 2; pixel_y = 0},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"Rz" = (/obj/structure/train_deco/tracks01,/obj/effect/landmark/train_marker/idle/red,/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/stones,/area/warfare/homebase/red/trainyard)
-"RC" = (/obj/structure/sign/warning/secure_area{icon_state = "securearea2"},/obj/hammereditor/nodraw,/turf/simulated/wall/perspecticrete,/area/warfare/homebase/red/hallway)
-"RD" = (/obj/structure/table/rack/nosmooth/wood/alt{dir = 6},/obj/item/flame/candle{pixel_x = -9; pixel_y = 5},/obj/item/flame/candle{pixel_x = -5; pixel_y = 12},/obj/item/flame/candle{pixel_x = -5; pixel_y = 2},/obj/item/flame/candle{pixel_x = -1; pixel_y = 5},/obj/item/storage/firstaid/regular{pixel_x = 7; pixel_y = -1},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"RI" = (/obj/effect/floor_decal/industrial/warning/dust{dir = 1},/obj/effect/darkout_teleporter/bluecoats,/obj/effect/floor_decal/train_deco/stripes{dir = 4},/obj/effect/lighting_dummy/daylight,/obj/effect/landmark/train_marker/teleport/blue,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/blue/trainyard)
-"RK" = (/obj/structure/closet/crate/wooden/large{icon_closed = "meatball"; icon_state = "meatball"; pixel_x = 4; pixel_y = 0},/obj/structure/closet/crate/wooden/large{pixel_x = 29; pixel_y = 25},/obj/structure/closet/crate/wooden/large{pixel_x = 4; pixel_y = 25},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/red/trainyard)
-"RL" = (/obj/structure/trench_wall{dir = 6},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/room)
-"RW" = (/obj/item/storage/firstaid/toxin,/obj/item/storage/firstaid/toxin,/obj/item/storage/firstaid/toxin,/obj/item/storage/firstaid/toxin,/obj/structure/table/rack/shelf/red,/obj/structure/table/woodentable/shelf{pixel_y = 26; density = 0},/obj/item/reagent_containers/glass/bottle/antique/slim/chloroform{pixel_x = 10; pixel_y = 32; icon_state = "slim_rd"},/obj/item/reagent_containers/rag{pixel_x = -5; pixel_y = 28},/obj/item/reagent_containers/glass/bottle/antique/slim/chloroform{pixel_x = 1; pixel_y = 31; icon_state = "slim_rd"},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"Sf" = (/obj/machinery/light/small/bunker{dir = 1},/obj/structure/announcementspeaker/blue{pixel_x = 0; dir = 1},/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/stoneroom)
-"Sg" = (/obj/hammereditor/nodraw/deco/shadowpaint{opacity = 1; dir = 4},/obj/structure/train_deco/tracks01,/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/stones,/area/warfare/homebase/blue/trainyard)
-"Sh" = (/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
-"Si" = (/obj/machinery/light/caged{pixel_y = 30; pixel_x = 0},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/one)
-"Sl" = (/obj/machinery/optable{dir = 8; pixel_x = 6; pixel_y = 3},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"Sn" = (/obj/effect/floor_decal/trench{dir = 9},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/two)
-"Sp" = (/obj/structure/trench_wall{dir = 1; pixel_y = -32},/obj/structure/closet/body_bag,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"Sr" = (/obj/machinery/light/caged{pixel_y = 28; pixel_x = 0},/turf/simulated/floor/wood,/area/warfare/homebase/blue)
-"Sy" = (/obj/effect/floor_decal/trench{dir = 9},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/two)
-"SD" = (/obj/machinery/light/caged{pixel_y = -14; dir = 1; pixel_x = 0},/obj/structure/trench_wall{dir = 4; pixel_x = -32; pixel_y = 0},/obj/structure/trench_wall/innercorners{dir = 4; pixel_x = -32; pixel_y = -32},/obj/structure/trench_wall/sequel{dir = 5; pixel_x = 0; pixel_y = -32},/obj/structure/closet/crate,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/room)
-"SI" = (/obj/structure/table/rack/nosmooth/metal,/obj/item/pen/blue{pixel_x = -12; pixel_y = 7},/obj/item/paper/crumpled{info = "///// ///// ///// //"; pixel_x = -1; pixel_y = 3; contents = "///// ///// ///// //"; name = "Tally"},/obj/item/storage/box/bodybags,/obj/machinery/light{dir = 1; pixel_y = 32},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"SN" = (/obj/structure/trench_wall{dir = 4},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/blue/two)
-"SO" = (/obj/machinery/light/caged{pixel_y = -1; dir = 1; pixel_x = 0},/turf/simulated/floor/dirty/indestructable,/area/warfare/battlefield/capture_point/blue/one)
-"SR" = (/obj/machinery/light/caged{pixel_y = 30; pixel_x = 0},/turf/simulated/floor/dirty/indestructable,/area/warfare/battlefield/capture_point/blue/two)
-"SU" = (/obj/effect/floor_decal/trench{dir = 6},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/one)
-"SV" = (/obj/machinery/light,/obj/effect/floor_decal/industrial/warning/dust{dir = 4},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/hallway)
-"SX" = (/mob/living/simple_animal/hostile/retaliate/rat,/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/two)
-"SY" = (/obj/machinery/light/small/bunker{dir = 1},/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/room)
-"SZ" = (/obj/effect/lighting_dummy/daylight,/obj/hammereditor/playerclip,/turf/simulated/floor/stones,/area/warfare/homebase/blue/trainyard)
-"Ta" = (/obj/item/storage/fancy/cigarettes,/obj/item/flame/lighter/random,/obj/structure/table/rack/nosmooth/wood/alt{dir = 4},/obj/item/flame/candle/blue,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"Td" = (/obj/machinery/camera{dir = 8; pixel_x = -2; pixel_y = 0},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/red/trainyard)
-"Te" = (/obj/effect/floor_decal/newcorner/grey/corner{dir = 4},/obj/effect/floor_decal/newcorner/grey/corner{dir = 1},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/hallway)
-"Th" = (/obj/structure/announcementspeaker/blue{pixel_x = 0; pixel_y = 32},/turf/simulated/floor/dirty/indestructable,/area/warfare/homebase/blue)
-"Ti" = (/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/stones,/area/warfare/homebase/blue/trainyard)
-"Tj" = (/obj/machinery/light/small/bunker{dir = 8},/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"Tk" = (/turf/simulated/floor/stones,/area/warfare/homebase/red/room)
-"Tm" = (/obj/structure/cargo_pad/red,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/room)
-"Tq" = (/obj/machinery/optable{dir = 1; pixel_x = -7},/obj/machinery/light,/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/room)
-"Tr" = (/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/wood,/area/warfare/homebase/blue/caproom)
-"Tt" = (/obj/structure/table/nosmooth/capnew{pixel_y = -4; dir = 8},/obj/item/clothing/accessory/medal/blue/stainless_steel{pixel_x = 8; pixel_y = 2},/obj/item/clothing/accessory/medal/blue/stainless_steel{pixel_x = 12; pixel_y = 2},/obj/item/clothing/accessory/medal/blue/silver{pixel_x = 16; pixel_y = 2},/obj/item/clothing/accessory/medal/blue/platinum{pixel_x = 20; pixel_y = 2},/obj/item/device/megaphone/blue{pixel_x = -1; pixel_y = 6},/obj/structure/table/nosmooth/capnew{pixel_y = 28; dir = 9},/turf/simulated/floor/wood,/area/warfare/homebase/blue/caproom)
-"Tu" = (/obj/structure/closet/crate/medical,/obj/item/wirecutters,/obj/item/wirecutters,/obj/item/storage/firstaid/regular,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"Tv" = (/obj/item/storage/firstaid/surgery,/obj/item/reagent_containers/spray/cleaner/warfare/red{pixel_x = 6; pixel_y = 14},/obj/structure/table/rack/nosmooth/metal,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"Tw" = (/turf/simulated/floor/stones,/area/warfare/homebase/blue/largeroom)
-"Tx" = (/turf/simulated/floor/urban/concrete,/area/warfare/homebase/blue/hallway)
-"TE" = (/obj/structure/trench_wall{dir = 4},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground)
-"TL" = (/obj/effect/landmark/start/redcoats,/obj/machinery/light/small{dir = 1; pixel_y = 37},/obj/structure/bed/chair/gray,/turf/simulated/floor/ert/metal01,/area/train/red)
-"TN" = (/obj/effect/floor_decal/trench{dir = 1},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/one)
-"TO" = (/obj/structure/table/rack/nosmooth/metal,/obj/item/reagent_containers/spray/cleaner/warfare/red{pixel_x = -12; pixel_y = 4},/obj/item/reagent_containers/spray/cleaner/warfare/red{pixel_x = 3; pixel_y = 0},/obj/item/reagent_containers/spray/cleaner/warfare/red{pixel_x = -5; pixel_y = 0},/obj/item/reagent_containers/spray/cleaner/warfare/red{pixel_x = 11; pixel_y = 4},/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/stoneroom)
-"TP" = (/obj/structure/bed/chair/throne{pixel_y = -3; buckle_pixel_shift = "x=0;y=-3"},/obj/effect/landmark/start{name = "Blue Captain"},/turf/simulated/floor/wood,/area/warfare/homebase/blue/caproom)
-"TW" = (/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/room)
-"Ua" = (/obj/machinery/light/small{dir = 1; pixel_y = 32},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"Uc" = (/obj/item/storage/firstaid/toxin,/obj/item/storage/firstaid/toxin,/obj/item/storage/firstaid/toxin,/obj/item/storage/firstaid/toxin,/obj/structure/table/rack/shelf/red,/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"Ue" = (/obj/structure/railing/urban{dir = 4},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/red/trainyard)
-"Uf" = (/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/stoneroom)
-"Uh" = (/obj/effect/sub_marker/surface{id = "MISSION"},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield)
-"Ui" = (/obj/structure/trench_wall{dir = 8},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/blue/two)
-"Uj" = (/obj/structure/closet/crate/trashcart,/obj/machinery/light/caged{pixel_y = -1; dir = 1; pixel_x = 0},/turf/simulated/floor/trenches,/area/warfare/homebase/red)
-"Um" = (/obj/machinery/light/caged{pixel_y = 30; pixel_x = 0},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/two)
-"Un" = (/obj/structure/defensive_barrier{secured = 1; dir = 8; pixel_x = 4; pixel_y = 2},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/space)
-"Ur" = (/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/urban/cinder,/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
-"Uv" = (/obj/effect/landmark/start/phoneoperator,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"Ux" = (/obj/effect/floor_decal/trench{dir = 4},/obj/structure/stairs/trenchstairs,/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/one)
-"Uy" = (/obj/effect/floor_decal/trench,/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/one)
-"UC" = (/obj/structure/closet/crate,/obj/random/canned_food/blue,/obj/random/canned_food/blue,/obj/random/canned_food/blue,/obj/structure/table/rack/holorack,/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/room)
-"UD" = (/obj/structure/closet/crate/wooden/large{icon_closed = "meatball"; icon_state = "meatball"; pixel_x = 4; pixel_y = 0},/obj/structure/closet/crate/wooden/large{pixel_x = 29; pixel_y = 25},/obj/structure/closet/crate/wooden/large{pixel_x = 4; pixel_y = 25},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/blue/trainyard)
-"UI" = (/obj/structure/trench_wall/sequel{dir = 8},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/bunker)
-"UJ" = (/obj/hammereditor/nodraw/deco/shadowpaint{opacity = 1; dir = 4},/turf/simulated/floor/exoplanet/water/shallow/lightless/urban,/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
-"UK" = (/obj/structure/train_deco/platform{pixel_y = 32; dir = 4; icon_state = "door_closed"; icon = 'icons/obj/doors/Doordoublesecglass1x2.dmi'},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/red/trainyard)
-"UM" = (/obj/effect/floor_decal/industrial/outline/grey,/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/red/trainyard)
-"UN" = (/obj/machinery/light/caged{pixel_y = 30; pixel_x = 0},/obj/effect/floor_decal/trench{dir = 1},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/two)
-"UP" = (/obj/structure/announcementspeaker/blue{pixel_y = 0; dir = 4},/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/hallway)
-"UV" = (/obj/random/canned_food/blue{pixel_x = -7; pixel_y = 11},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/room)
-"UX" = (/obj/item/storage/firstaid/fire,/obj/item/storage/firstaid/fire,/obj/item/storage/firstaid/fire,/obj/item/storage/firstaid/fire,/obj/structure/table/rack/shelf/red,/obj/machinery/light{dir = 4},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"UY" = (/turf/simulated/wall/perspecticrete,/area/warfare/homebase/blue/stoneroom)
-"Vc" = (/obj/structure/dirt_wall,/turf/simulated/floor/dirty/tough,/area/warfare/battlefield/capture_point/blue/two)
-"Vd" = (/obj/hammereditor/nodraw/deco/shadowpaint{opacity = 1; dir = 1},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/stones,/area/warfare/homebase/blue/trainyard)
-"Ve" = (/obj/structure/trench_wall{dir = 4; pixel_x = -32; pixel_y = 0},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/space)
-"Vf" = (/obj/machinery/light{dir = 4},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/hallway)
-"Vg" = (/obj/machinery/vending/soldier/blue,/turf/simulated/floor/tiled,/area/warfare/homebase/blue/largeroom)
-"Vi" = (/obj/machinery/sleeper{dir = 4; icon_state = "sleeper_0"},/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/room)
-"Vj" = (/obj/structure/dirt_wall,/turf/simulated/floor/dirty/fake,/area/warfare/battlefield/capture_point/blue/one)
-"Vu" = (/obj/machinery/light/small{dir = 1; pixel_y = 32},/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/room)
-"Vx" = (/obj/structure/cargo_pad/red,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/largeroom)
-"VC" = (/obj/structure/trench_wall{dir = 5; pixel_x = 32; layer = 28},/obj/structure/trench_wall/innercorners{dir = 1; pixel_x = 32; pixel_y = 31},/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"VE" = (/obj/machinery/door/airlock/multi_tile/metal/maintenance/red,/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/hallway)
-"VJ" = (/obj/structure/closet/secure_closet/medical1/warfare,/obj/structure/announcementspeaker/red{id = "Bluecoats"; pixel_y = 32},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"VL" = (/turf/unsimulated/wall/submarine/doors{dir = 1},/area/train/blue)
-"VO" = (/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"VP" = (/turf/simulated/mineral{health = 999999},/area/warfare/homebase/red)
-"VQ" = (/turf/simulated/wall/perspecticrete,/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
-"VR" = (/obj/structure/announcementspeaker/blue{pixel_y = 32},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"VS" = (/obj/item/storage/firstaid/surgery,/obj/structure/table/rack/nosmooth/wood/alt{dir = 5},/obj/item/flame/candle/blue,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"VT" = (/obj/machinery/light{dir = 8},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/stoneroom)
-"VZ" = (/obj/effect/landmark/start{name = "Blue Squad Leader"},/turf/simulated/floor/stones,/area/warfare/homebase/blue/room)
-"Wa" = (/obj/machinery/bodyscanner{dir = 4; icon_state = "body_scanner_0"},/obj/machinery/light/small/bunker{dir = 4; pixel_x = 0; pixel_y = 15},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"Wf" = (/obj/structure/trench_wall{dir = 10},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/room)
-"Wi" = (/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"Wj" = (/obj/structure/curtain,/obj/structure/curtain,/turf/simulated/floor/stones,/area/warfare/homebase/blue/room)
-"Wk" = (/obj/structure/trench_wall{dir = 8},/obj/structure/warfare/thehatch{dir = 8},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/indoors)
-"Wl" = (/obj/effect/floor_decal/trench{dir = 5},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/two)
-"Wm" = (/obj/structure/vehicle/train/long_passenger{pixel_y = 16; id = "Redcoats"},/turf/space,/area/space)
-"Wp" = (/obj/machinery/light/caged{pixel_y = 28; pixel_x = 0},/obj/structure/closet/crate/trashcart,/turf/simulated/floor/trenches,/area/warfare/homebase/blue)
-"Wq" = (/obj/machinery/light{dir = 4},/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/hallway)
-"Ws" = (/obj/structure/poster/red,/turf/simulated/wall/perspecticrete,/area/warfare/homebase/red/room)
-"Wu" = (/obj/machinery/sleeper,/obj/structure/trench_wall/innercorners{dir = 4; pixel_x = -32; pixel_y = -32},/obj/structure/trench_wall{dir = 9; pixel_x = -32; layer = 28},/obj/machinery/light/caged{dir = 1; pixel_y = -1},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"Ww" = (/turf/simulated/wall/perspecticrete,/area/warfare/homebase/red/stoneroom)
-"WD" = (/obj/structure/stairs/trenchstairs,/obj/structure/announcementspeaker/blue{pixel_x = 0; dir = 1},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/one)
-"WF" = (/obj/structure/stairs/west,/obj/machinery/light/small/bunker{dir = 1},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"WG" = (/obj/structure/trench_wall{dir = 4; pixel_x = -32; pixel_y = 0},/obj/structure/trench_wall/innercorners{pixel_x = -32; pixel_y = 31},/obj/structure/stairs/trenchstairs{dir = 1},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/two)
-"WH" = (/obj/structure/train_deco/tracks01,/obj/hammereditor/nodraw/deco/shadowpaint{opacity = 1; dir = 4},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/stones,/area/warfare/homebase/blue/trainyard)
-"WJ" = (/obj/structure/announcementspeaker/red{id = "Bluecoats"; pixel_y = 32},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/hallway)
-"WL" = (/obj/machinery/camera{dir = 4; pixel_x = 2; pixel_y = 0},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/blue/trainyard)
-"WR" = (/obj/machinery/optable{pixel_x = 4},/obj/machinery/light,/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"WS" = (/obj/structure/trench_wall/innercorners{dir = 1},/obj/structure/trench_wall{dir = 1},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/room)
-"WU" = (/obj/effect/floor_decal/trench{dir = 9},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/one)
-"WX" = (/obj/structure/trench_wall{dir = 4},/obj/structure/warfare/thehatch{dir = 4},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/indoors)
-"Xa" = (/obj/effect/landmark{name = "tdome1"},/obj/effect/ruin_loader/warfare_mid,/turf/simulated/mineral{health = 999999},/area/space)
-"Xb" = (/obj/structure/trench_wall{dir = 4; pixel_x = -32; pixel_y = 0},/obj/structure/table/rack/holorack,/obj/machinery/light/caged{pixel_y = 30; pixel_x = 0},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/room)
-"Xe" = (/obj/machinery/light/small/bunker{dir = 1},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"Xf" = (/obj/machinery/light{dir = 8},/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/hallway)
-"Xj" = (/obj/effect/floor_decal/stones{dir = 8},/turf/simulated/floor/dirty/indestructable,/area/warfare/battlefield/trench_section)
-"Xk" = (/obj/effect/floor_decal/industrial/warning/dust{dir = 8},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/blue/trainyard)
-"Xl" = (/obj/effect/floor_decal/industrial/warning/dust{dir = 8},/obj/effect/lighting_dummy/daylight,/obj/effect/landmark/train_marker/teleport/red,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/red/trainyard)
-"Xn" = (/obj/machinery/light/small/bunker{dir = 8},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/hallway)
-"Xu" = (/obj/machinery/door/airlock/bunker/red,/turf/simulated/floor/stones,/area/warfare/homebase/red/largeroom)
-"Xx" = (/obj/effect/floor_decal/newcorner/grey/diagonal,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/hallway)
-"Xy" = (/obj/item/ammo_box/shotgun,/obj/structure/table/rack/nosmooth/wood/alt{dir = 6},/obj/item/flame/candle/blue,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"Xz" = (/obj/machinery/light/small/bunker{dir = 4},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/hallway)
-"XA" = (/obj/machinery/light/small/bunker{dir = 1},/turf/simulated/floor/wood,/area/warfare/homebase/red/caproom)
-"XC" = (/obj/structure/reagent_dispensers/coolanttank,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/room)
-"XD" = (/obj/structure/trench_wall/sequel{dir = 4},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/bunker)
-"XH" = (/obj/structure/bed/chair/blue{dir = 1; pixel_x = 0; pixel_y = 11; buckle_pixel_shift = "x=0;y=11"},/turf/simulated/floor/wood,/area/warfare/homebase/blue/caproom)
-"XO" = (/obj/effect/floor_decal/trench{dir = 10},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/trench_section/underground)
-"XS" = (/obj/structure/trench_wall/innercorners{dir = 1},/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/underground/bunker)
-"XX" = (/turf/simulated/floor/wood,/area/warfare/homebase/blue/caproom)
-"XY" = (/obj/structure/table/rack/nosmooth/wood/alt{dir = 4},/obj/structure/bed/chair/red{pixel_x = -15; pixel_y = 4},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"Yb" = (/obj/machinery/computer/operating{icon_state = "console"},/obj/machinery/light/caged{dir = 1; pixel_y = -1},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"Yd" = (/obj/effect/floor_decal/newcorner/grey/quarter,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/hallway)
-"Ye" = (/obj/structure/closet/crate/wooden{pixel_x = -3; pixel_y = 12},/obj/structure/closet/crate/wooden{pixel_x = -10; pixel_y = 1},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/blue/trainyard)
-"Yh" = (/obj/structure/closet/crate,/obj/random/canned_food/blue,/obj/random/canned_food/blue,/obj/random/canned_food/blue,/obj/structure/table/rack/holorack,/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/room)
-"Yl" = (/obj/structure/table/rack/nosmooth/wood/alt{dir = 4},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/largeroom)
-"Yn" = (/obj/effect/floor_decal/trench{dir = 10},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/red/one)
-"Yt" = (/obj/structure/cargo_pad/bue/captain,/obj/structure/warfare_itemeater/blue{pixel_y = 32},/turf/simulated/floor/wood,/area/warfare/homebase/blue/caproom)
-"Yu" = (/turf/unsimulated/wall/submarine/doors{dir = 4},/area/train/red)
-"Yy" = (/obj/machinery/door/airlock/multi_tile/metal/maintenance/red{locked = 1; maxhealth = 500000},/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/hallway)
-"Yz" = (/turf/simulated/floor/dirty/indestructable,/area/warfare/homebase/blue/trainyard)
-"YD" = (/obj/structure/table/rack,/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/stoneroom)
-"YE" = (/obj/structure/train_deco/tracks01,/obj/hammereditor/nodraw/deco/shadowpaint{opacity = 1; dir = 8},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/stones,/area/warfare/homebase/red/trainyard)
-"YJ" = (/obj/structure/train_deco/tracks01,/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/destroyed,/area/warfare/homebase/blue/trainyard)
-"YO" = (/obj/sound_emitter/periodic/env_leak,/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/room)
-"YS" = (/obj/effect/landmark/test/safe_turf,/turf/simulated/mineral{health = 999999},/area/warfare/homebase/red)
-"YU" = (/obj/structure/closet/crate/wooden{pixel_x = -3; pixel_y = 12},/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/concrete,/area/warfare/homebase/blue/trainyard)
-"YW" = (/obj/structure/trench_wall{dir = 6},/obj/structure/trench_wall,/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/trench_section/room)
-"Zb" = (/obj/item/device/flashlight{on = 1; pixel_x = 5; pixel_y = 2},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/room)
-"Zc" = (/turf/simulated/mineral{health = 999999},/area/warfare/battlefield)
-"Zf" = (/obj/structure/trench_wall{dir = 1; pixel_y = -32},/obj/structure/closet/body_bag,/obj/effect/decal/cleanable/cobweb2{dir = 8},/obj/structure/trench_wall/innercorners{dir = 8; pixel_x = 32; pixel_y = -32},/turf/simulated/floor/wood,/area/warfare/battlefield/trench_section/underground/indoors)
-"Zi" = (/obj/structure/trench_wall{dir = 4; pixel_x = -32; pixel_y = 0},/obj/structure/trench_wall/innercorners{pixel_x = -32; pixel_y = 31},/obj/structure/stairs/trenchstairs{dir = 1},/turf/simulated/floor/trenches/underground{icon_state = "trench"; color = "#ffffff"},/area/warfare/battlefield/capture_point/blue/one)
-"Zm" = (/obj/machinery/door/unpowered/simple/wood/captain{initial_lock_value = "captain"; locked = 1},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/caproom)
-"Zo" = (/obj/structure/announcementspeaker/red{id = "Bluecoats"; pixel_y = 32},/turf/simulated/floor/urban/tiles/blue,/area/warfare/homebase/blue/room)
-"Zp" = (/obj/machinery/light/small/bunker{dir = 1},/obj/structure/announcementspeaker/blue{pixel_x = 0; dir = 1},/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
-"Zr" = (/obj/effect/decal/cleanable/blood/gibs,/turf/simulated/floor/urban/tiles,/area/warfare/homebase/red/room)
-"Zs" = (/obj/structure/trench_wall/innercorners,/turf/simulated/mineral{health = 999999},/area/warfare/battlefield/capture_point/red/one)
-"Zu" = (/obj/structure/trench_wall/sequel{dir = 8},/obj/hammereditor/nodraw,/turf/simulated/mineral{health = 999999},/area/space)
-"Zz" = (/obj/effect/lighting_dummy/daylight,/turf/simulated/floor/urban/destroyed,/area/warfare/homebase/blue/trainyard)
-"ZB" = (/obj/effect/decal/cleanable/cobweb2{dir = 8},/obj/structure/cargo_pad{pixel_x = 5; pixel_y = -3},/obj/structure/cargo_pad{pixel_x = -2; pixel_y = 5},/obj/structure/cargo_pad{pixel_x = 4; pixel_y = 8},/obj/structure/cargo_pad{pixel_x = 7; pixel_y = 6},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/blue/room)
-"ZF" = (/obj/structure/soldiercryo/special/red,/obj/machinery/light/small/bunker{dir = 8},/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/room)
-"ZI" = (/obj/structure/announcementspeaker/red{pixel_x = 0; dir = 8},/turf/simulated/floor/concrete/random,/area/warfare/homebase/red/hallway)
-"ZJ" = (/obj/item/device/compass,/obj/structure/table/rack/nosmooth/wood,/turf/simulated/floor/stones,/area/warfare/homebase/blue/room)
-"ZM" = (/obj/structure/announcementspeaker/blue{pixel_x = 0; dir = 1},/turf/simulated/floor/wood,/area/warfare/homebase/blue/caproom)
-"ZP" = (/obj/machinery/door/airlock/multi_tile/metal/maintenance/blue,/turf/simulated/floor/concrete/random,/area/warfare/battlefield/trench_section/room)
-"ZQ" = (/obj/structure/announcementspeaker/red{pixel_x = 0; dir = 1},/turf/simulated/floor/wood,/area/warfare/homebase/red/caproom)
-"ZV" = (/obj/hammereditor/nodraw,/turf/simulated/floor/urban/cinder,/area/warfare/homebase/red/room)
-"ZY" = (/obj/item/storage/box/matches,/obj/structure/table/rack/nosmooth/wood/alt{dir = 4},/obj/item/flame/candle/blue,/turf/simulated/floor/concrete/random,/area/warfare/homebase/blue/largeroom)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/space)
+"ab" = (
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/red)
+"ac" = (
+/obj/structure/stairs/trenchstairs,
+/obj/structure/announcementspeaker/red{
+	pixel_x = 0;
+	dir = 1
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"ad" = (
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/largeroom)
+"ae" = (
+/obj/structure/bed/chair/throne{
+	pixel_y = -3;
+	buckle_pixel_shift = "x=0;y=-3"
+	},
+/obj/effect/landmark/start{
+	name = "Red Logistics Lieutenant"
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/largeroom)
+"af" = (
+/obj/effect/phone_line,
+/obj/item/paper_bin{
+	pixel_x = 4;
+	pixel_y = 10
+	},
+/obj/item/pen/red{
+	pixel_x = 1;
+	pixel_y = 10
+	},
+/obj/structure/table/nosmooth/capnew{
+	pixel_y = -4;
+	dir = 4
+	},
+/obj/item/storage/fancy/cigarettes/cigarillo{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/structure/table/nosmooth/capnew{
+	pixel_y = 28;
+	dir = 5
+	},
+/obj/structure/window/reinforced{
+	pixel_x = 0;
+	pixel_y = 7
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/largeroom)
+"ag" = (
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/blue)
+"ah" = (
+/obj/structure/sign/neon/cargo,
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/blue/largeroom)
+"ai" = (
+/obj/structure/poster/blue,
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/blue/largeroom)
+"aj" = (
+/obj/structure/cargo_pad/blue,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/room)
+"ak" = (
+/obj/structure/bed/chair/throne{
+	pixel_y = -3;
+	buckle_pixel_shift = "x=0;y=-3"
+	},
+/obj/effect/landmark/start{
+	name = "Blue Logistics Lieutenant"
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/largeroom)
+"al" = (
+/obj/effect/phone_line,
+/obj/item/paper_bin{
+	pixel_x = 4;
+	pixel_y = 10
+	},
+/obj/structure/table/nosmooth/capnew{
+	pixel_y = -4;
+	dir = 4
+	},
+/obj/item/pen/blue{
+	pixel_x = 2;
+	pixel_y = 10
+	},
+/obj/item/storage/fancy/cigar{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/structure/table/nosmooth/capnew{
+	pixel_y = 28;
+	dir = 5
+	},
+/obj/structure/window/reinforced{
+	pixel_x = 0;
+	pixel_y = 7
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/largeroom)
+"am" = (
+/obj/structure/trench_wall{
+	dir = 4
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/bunker)
+"an" = (
+/obj/structure/table/nosmooth/capnew{
+	pixel_y = -4
+	},
+/obj/item/device/flashlight/lamp/captain/blue{
+	pixel_x = 15;
+	pixel_y = 9
+	},
+/obj/item/clipboard{
+	pixel_x = -8;
+	pixel_y = 1
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/largeroom)
+"ao" = (
+/obj/structure/closet/secure_closet/warfare/newver,
+/mob/living/simple_animal/hostile/retaliate/rat,
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/trench_section/underground)
+"ap" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	icon_state = "rwindow"
+	},
+/obj/structure/cargo_pad/red,
+/obj/sound_emitter/periodic/env_leak,
+/obj/machinery/light/small/bunker{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/room)
+"aq" = (
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/homebase/blue)
+"ar" = (
+/obj/machinery/light/caged{
+	dir = 4;
+	pixel_x = -10;
+	pixel_y = 0
+	},
+/mob/living/simple_animal/hostile/retaliate/rat,
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/trench_section/underground)
+"as" = (
+/obj/effect/floor_decal/trench{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/retaliate/rat,
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"at" = (
+/obj/effect/floor_decal/trench{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/retaliate/rat,
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"au" = (
+/obj/effect/landmark/start{
+	name = "Blue Soldier"
+	},
+/obj/structure/bed/chair/blue,
+/obj/machinery/light/small/bunker{
+	dir = 4
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"av" = (
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/stoneroom)
+"aw" = (
+/obj/effect/landmark/start{
+	name = "Blue Soldier"
+	},
+/obj/structure/bed/chair/blue{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 11;
+	buckle_pixel_shift = "x=0;y=11"
+	},
+/obj/machinery/light/small/bunker{
+	dir = 4
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"ax" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"ay" = (
+/obj/machinery/light/caged{
+	pixel_y = -14;
+	dir = 1;
+	pixel_x = 0
+	},
+/obj/item/device/compass,
+/obj/item/device/compass,
+/obj/structure/table/rack/nosmooth/wood,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/room)
+"az" = (
+/obj/structure/bed/chair/wheelchair,
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/stoneroom)
+"aB" = (
+/obj/effect/floor_decal/newcorner/grey,
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/hallway)
+"aC" = (
+/obj/item/storage/fancy/cigarettes/jerichos,
+/obj/item/flame/lighter/random,
+/obj/structure/table/rack/nosmooth/wood/alt,
+/obj/item/flame/candle/blue,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"aD" = (
+/obj/item/storage/firstaid/regular,
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 4
+	},
+/obj/item/flame/candle/blue,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"aE" = (
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 6
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"aF" = (
+/obj/item/storage/box/matches,
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 6
+	},
+/obj/item/flame/candle/blue,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"aG" = (
+/obj/item/device/compass,
+/obj/item/device/compass,
+/obj/item/device/compass,
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 4
+	},
+/obj/item/flame/candle/blue,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"aH" = (
+/obj/item/storage/fancy/cigarettes,
+/obj/item/flame/lighter/random,
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 5
+	},
+/obj/item/flame/candle/blue,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"aI" = (
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 4
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"aJ" = (
+/obj/structure/closet/secure_closet/warfare,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/room)
+"aK" = (
+/obj/item/storage/fancy/cigarettes/carcinomas,
+/obj/item/ammo_box/rifle,
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 5
+	},
+/obj/item/flame/candle/blue,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"aL" = (
+/obj/structure/reagent_dispensers/watertank/red,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"aM" = (
+/obj/item/storage/fancy/cigarettes/carcinomas,
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 5
+	},
+/obj/item/flame/candle/blue,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"aN" = (
+/obj/item/wirecutters,
+/obj/item/storage/firstaid/regular,
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 6
+	},
+/obj/item/flame/candle/blue,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"aP" = (
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/hallway)
+"aR" = (
+/obj/item/storage/fancy/cigarettes,
+/obj/item/flame/lighter/random,
+/obj/machinery/light/caged{
+	pixel_y = -1;
+	dir = 1;
+	pixel_x = 0
+	},
+/obj/structure/table/rack/nosmooth/metal{
+	dir = 1
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/room)
+"aS" = (
+/obj/structure/closet/crate,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"aT" = (
+/obj/structure/trench_wall,
+/obj/structure/trench_wall{
+	dir = 1
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/room)
+"aU" = (
+/obj/structure/destruction_computer/blue,
+/turf/simulated/floor/tiled,
+/area/warfare/homebase/blue/largeroom)
+"aV" = (
+/obj/structure/stairs/west,
+/obj/machinery/light/small/bunker{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"aW" = (
+/obj/item/storage/fancy/cigarettes,
+/obj/item/flame/lighter/zippo,
+/obj/machinery/light/caged{
+	pixel_y = -1;
+	dir = 1;
+	pixel_x = 0
+	},
+/obj/structure/announcementspeaker/blue{
+	pixel_y = 0;
+	dir = 8
+	},
+/obj/structure/table/rack/nosmooth/metal{
+	dir = 4
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/room)
+"aX" = (
+/turf/simulated/floor/tiled/ramp{
+	dir = 8;
+	icon_state = "ramptop"
+	},
+/area/warfare/homebase/blue/stoneroom)
+"aY" = (
+/obj/machinery/light/small/bunker{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/room)
+"aZ" = (
+/obj/hammereditor/nodraw/deco/shadowpaint,
+/obj/hammereditor/nodraw/deco/shadowpaint{
+	opacity = 1;
+	dir = 8
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/trainyard)
+"bb" = (
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/blue/div)
+"bc" = (
+/obj/hammereditor/nodraw/deco/shutter_half,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/room)
+"bd" = (
+/obj/structure/stairs/trenchstairs{
+	dir = 1
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/two)
+"be" = (
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/stoneroom)
+"bg" = (
+/obj/structure/poster/red,
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/red/largeroom)
+"bh" = (
+/obj/effect/floor_decal/trench,
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/two)
+"bi" = (
+/turf/simulated/wall/perspecticrete,
+/area/warfare/battlefield/trench_section/stoneroom)
+"bk" = (
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/two)
+"bl" = (
+/obj/structure/bed/chair/blue{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 11;
+	buckle_pixel_shift = "x=0;y=11"
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/largeroom)
+"bm" = (
+/obj/structure/table/nosmooth/capnew{
+	pixel_y = -4
+	},
+/obj/item/device/flashlight/lamp/captain{
+	pixel_x = 15;
+	pixel_y = 9
+	},
+/obj/item/clipboard{
+	pixel_x = -8;
+	pixel_y = 2
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/largeroom)
+"bn" = (
+/obj/machinery/light/small/bunker{
+	dir = 4
+	},
+/obj/machinery/button/remote/blast_door/lever{
+	id = "red";
+	pixel_y = 32
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"bo" = (
+/obj/structure/trench_wall,
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"bq" = (
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/largeroom)
+"br" = (
+/obj/structure/reagent_dispensers/watertank{
+	pixel_x = 3;
+	pixel_y = 1
+	},
+/obj/machinery/light/caged{
+	dir = 4;
+	pixel_x = -2;
+	pixel_y = 0
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/room)
+"bs" = (
+/obj/item/storage/fancy/cigarettes/luckystars,
+/obj/item/flame/lighter/random,
+/obj/item/ammo_box/rifle,
+/obj/structure/table/rack/nosmooth/wood/alt,
+/obj/item/flame/candle/blue,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"bt" = (
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"bu" = (
+/obj/structure/closet/crate,
+/obj/random/canned_food/red,
+/obj/random/canned_food/red,
+/obj/random/canned_food/red,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"bw" = (
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"bx" = (
+/obj/structure/announcementspeaker/blue{
+	pixel_x = 0;
+	dir = 1
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/hallway)
+"bz" = (
+/obj/item/storage/box/matches,
+/obj/structure/table/rack/nosmooth/wood/alt,
+/obj/item/flame/candle/blue,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"bB" = (
+/obj/structure/table/rack/nosmooth/wood/alt,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"bC" = (
+/obj/item/flame/candle,
+/obj/item/storage/firstaid/regular,
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 4
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"bD" = (
+/obj/structure/trench_wall/innercorners{
+	dir = 4
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/bunker)
+"bF" = (
+/obj/item/flame/candle,
+/obj/item/device/compass,
+/obj/item/device/compass,
+/obj/item/device/compass,
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 4
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"bG" = (
+/obj/item/storage/fancy/cigarettes,
+/obj/item/flame/candle,
+/obj/item/flame/lighter/random,
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 4
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"bH" = (
+/obj/item/flame/candle,
+/obj/item/storage/firstaid/surgery,
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 5
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"bJ" = (
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular,
+/obj/structure/table/rack/shelf/red,
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/room)
+"bK" = (
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 5
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"bL" = (
+/obj/item/flame/candle,
+/obj/item/storage/fancy/cigarettes/carcinomas,
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 5
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"bM" = (
+/obj/item/flame/candle,
+/obj/item/wirecutters,
+/obj/item/storage/firstaid/regular,
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 6
+	},
+/obj/structure/announcementspeaker/red{
+	pixel_x = 0;
+	dir = 8
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"bN" = (
+/obj/structure/defensive_barrier{
+	secured = 1;
+	dir = 8;
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/hammereditor/nodraw,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/room)
+"bO" = (
+/obj/effect/landmark/start{
+	name = "Red Soldier"
+	},
+/obj/structure/bed/chair/red{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 11;
+	buckle_pixel_shift = "x=0;y=11"
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"bP" = (
+/obj/effect/floor_decal/trench{
+	dir = 4
+	},
+/obj/structure/stairs/trenchstairs,
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"bR" = (
+/obj/structure/dirt_wall,
+/turf/simulated/floor/dirty/tough,
+/area/warfare/battlefield/capture_point/red/two)
+"bS" = (
+/obj/structure/destruction_computer/red,
+/turf/simulated/floor/tiled,
+/area/warfare/homebase/red/largeroom)
+"bT" = (
+/obj/item/storage/fancy/cigarettes,
+/obj/item/flame/lighter/random,
+/obj/machinery/light/caged{
+	pixel_y = 30;
+	pixel_x = 0
+	},
+/obj/structure/announcementspeaker/blue{
+	pixel_y = 0;
+	dir = 4
+	},
+/obj/structure/table/rack/nosmooth/metal{
+	dir = 6
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/room)
+"bU" = (
+/turf/unsimulated/wall/hammereditor/dev2,
+/area/warfare/homebase/red/stoneroom)
+"bV" = (
+/obj/effect/landmark/start{
+	name = "Blue Soldier"
+	},
+/obj/structure/bed/chair/blue,
+/obj/machinery/light/small/bunker{
+	dir = 8
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"bW" = (
+/obj/machinery/light/small/bunker{
+	dir = 1
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/room)
+"bY" = (
+/obj/effect/landmark/start{
+	name = "Red Squad Leader"
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/room)
+"bZ" = (
+/obj/structure/toilet{
+	dir = 8;
+	icon_state = "toilet00"
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/room)
+"ca" = (
+/obj/effect/landmark/start{
+	name = "Red Bartender"
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/room)
+"cb" = (
+/obj/effect/landmark/start{
+	name = "Red Soldier"
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/room)
+"cc" = (
+/obj/effect/landmark/start{
+	name = "Red Scavenger"
+	},
+/obj/structure/toilet{
+	dir = 8;
+	icon_state = "toilet00"
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/room)
+"cd" = (
+/obj/effect/landmark/start{
+	name = "Red Scavenger"
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/room)
+"cf" = (
+/obj/effect/lighting_dummy/daylight,
+/obj/effect/landmark/train_marker/teleport/red,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/red/trainyard)
+"cg" = (
+/obj/structure/stairs/trenchstairs,
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/two)
+"ch" = (
+/obj/machinery/light/caged{
+	pixel_y = -1;
+	dir = 1;
+	pixel_x = 16
+	},
+/obj/structure/trench_wall{
+	dir = 9;
+	pixel_x = -32;
+	layer = 28
+	},
+/obj/structure/table/rack/shelf/red,
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"ci" = (
+/obj/effect/sub_marker/dive{
+	id = "MISSION"
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield)
+"cj" = (
+/obj/structure/bed,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/room)
+"cl" = (
+/obj/structure/closet/secure_closet/warfare,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/room)
+"cn" = (
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/blue/two)
+"co" = (
+/turf/simulated/floor/ert/metal01,
+/area/train/red)
+"cp" = (
+/obj/structure/announcementspeaker/blue{
+	pixel_x = 0;
+	dir = 1
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/largeroom)
+"cq" = (
+/obj/structure/closet/secure_closet/warfare/newver,
+/obj/item/crowbar,
+/obj/item/crowbar,
+/obj/item/crowbar,
+/obj/structure/banner/blue/small{
+	pixel_y = 32
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/largeroom)
+"cr" = (
+/obj/structure/closet/secure_closet/warfare,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/room)
+"cs" = (
+/obj/item/gun/projectile/revolver{
+	name = "Authority";
+	desc = "Over something as fundemental as life itself"
+	},
+/obj/machinery/light/small/bunker{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 5
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"ct" = (
+/obj/structure/trench_wall{
+	dir = 6
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"cu" = (
+/obj/structure/announcementspeaker/blue{
+	pixel_y = 0;
+	dir = 4
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/hallway)
+"cw" = (
+/obj/structure/trench_wall{
+	dir = 4;
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/structure/announcementspeaker/red{
+	pixel_x = 0;
+	dir = 4
+	},
+/obj/structure/table/rack/shelf/red,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/room)
+"cx" = (
+/obj/effect/floor_decal/trench{
+	dir = 4
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"cz" = (
+/obj/effect/floor_decal/trench{
+	dir = 4
+	},
+/obj/structure/banner/blue/small{
+	pixel_y = 32
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"cA" = (
+/obj/effect/floor_decal/trench{
+	dir = 8
+	},
+/obj/machinery/light/caged{
+	pixel_y = -1;
+	dir = 1;
+	pixel_x = 0
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"cB" = (
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground)
+"cC" = (
+/obj/structure/soldiercryo/special/blue,
+/obj/structure/announcementspeaker/red{
+	id = "Bluecoats";
+	pixel_y = 32
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/stoneroom)
+"cD" = (
+/obj/effect/phone_line,
+/obj/item/paper_bin{
+	pixel_x = 4;
+	pixel_y = 10
+	},
+/obj/item/pen/red{
+	pixel_x = 1;
+	pixel_y = 10
+	},
+/obj/structure/table/nosmooth/capnew{
+	pixel_y = -4;
+	dir = 4
+	},
+/obj/item/storage/fancy/cigarettes/cigarillo{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/item/flame/lighter/zippo{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/turf/simulated/floor/wood,
+/area/warfare/homebase/red/caproom)
+"cE" = (
+/obj/machinery/light/caged{
+	pixel_y = 28;
+	pixel_x = 0
+	},
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/homebase/blue)
+"cF" = (
+/obj/effect/floor_decal/trench{
+	dir = 8
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"cG" = (
+/obj/effect/floor_decal/trench{
+	dir = 10
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/two)
+"cH" = (
+/obj/structure/closet/secure_closet/medical1/warfare,
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"cJ" = (
+/obj/machinery/shower{
+	dir = 8;
+	icon_state = "shower"
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"cK" = (
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"cL" = (
+/obj/machinery/light/small/bunker{
+	dir = 8
+	},
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/hallway)
+"cN" = (
+/obj/structure/table/rack/holorack,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/room)
+"cO" = (
+/obj/structure/sign/warning/biohazard,
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 4
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/hallway)
+"cP" = (
+/obj/structure/closet/crate,
+/obj/random/canned_food/blue,
+/obj/random/canned_food/blue,
+/obj/structure/table/rack/holorack,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/room)
+"cR" = (
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/hallway)
+"cS" = (
+/obj/structure/toilet{
+	dir = 8;
+	icon_state = "toilet00"
+	},
+/obj/machinery/light/small/bunker{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/room)
+"cU" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
+"cV" = (
+/obj/structure/trench_wall{
+	dir = 4;
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/structure/table/rack/holorack,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/room)
+"cY" = (
+/obj/effect/floor_decal/newcorner/grey/diagonal,
+/obj/effect/floor_decal/newcorner/grey/corner{
+	dir = 4
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/hallway)
+"cZ" = (
+/obj/structure/table/rack/nosmooth/metal,
+/obj/item/storage/firstaid/surgery,
+/obj/machinery/light/small,
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"da" = (
+/obj/structure/train_deco/sides{
+	dir = 1
+	},
+/obj/hammereditor/playerclip,
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/trainyard)
+"db" = (
+/obj/structure/stairs/trenchstairs{
+	dir = 1
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"dd" = (
+/obj/machinery/door/airlock/multi_tile/metal/maintenance{
+	dir = 1;
+	icon_state = "door_closed";
+	name = "Emergency Medical";
+	locked = 1;
+	maxhealth = 5000000
+	},
+/obj/hammereditor/nodraw,
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/blue/hallway)
+"de" = (
+/obj/structure/banner/blue/small{
+	pixel_y = 32
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"df" = (
+/obj/structure/announcementspeaker/blue{
+	pixel_x = 0;
+	dir = 1
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"dg" = (
+/obj/structure/stairs/trenchstairs,
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"dh" = (
+/obj/structure/stairs/trenchstairs{
+	dir = 1
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/one)
+"di" = (
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/red/one)
+"dj" = (
+/obj/structure/trench_wall{
+	dir = 6
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/blue/two)
+"dk" = (
+/mob/living/simple_animal/hostile/retaliate/rat,
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/one)
+"dl" = (
+/turf/simulated/wall/perspecticrete,
+/area/warfare/battlefield/trench_section/room)
+"dn" = (
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"do" = (
+/obj/machinery/light/caged{
+	pixel_y = 30;
+	pixel_x = 0
+	},
+/obj/structure/closet/crate/club,
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/room)
+"dp" = (
+/obj/structure/toilet{
+	dir = 4;
+	icon_state = "toilet00"
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/room)
+"dr" = (
+/obj/structure/stairs/trenchstairs,
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/one)
+"ds" = (
+/obj/structure/announcementspeaker/red{
+	pixel_x = 0;
+	dir = 4
+	},
+/obj/structure/table/rack/shelf/red,
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/room)
+"dt" = (
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/stoneroom)
+"du" = (
+/obj/structure/trench_wall,
+/obj/structure/announcementspeaker/red,
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/indoors)
+"dv" = (
+/obj/structure/table/rack/holorack,
+/obj/machinery/light/caged{
+	dir = 1;
+	pixel_y = -1
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/room)
+"dw" = (
+/obj/structure/table/woodentable/shelf{
+	pixel_y = 13
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/largeroom)
+"dx" = (
+/obj/structure/trench_wall/sequel{
+	dir = 4
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/red/one)
+"dy" = (
+/obj/item/storage/fancy/cigarettes,
+/obj/item/flame/lighter/random,
+/obj/machinery/light/caged{
+	pixel_y = -1;
+	dir = 1;
+	pixel_x = 0
+	},
+/obj/structure/announcementspeaker/red{
+	pixel_x = 0;
+	dir = 4
+	},
+/obj/structure/table/rack/nosmooth/metal{
+	dir = 1
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/room)
+"dz" = (
+/obj/item/storage/fancy/cigarettes,
+/obj/item/flame/lighter/zippo,
+/obj/machinery/light/caged{
+	pixel_y = -1;
+	dir = 1;
+	pixel_x = 0
+	},
+/obj/structure/table/rack/nosmooth/metal{
+	dir = 4
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/room)
+"dA" = (
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"dC" = (
+/obj/structure/trench_wall{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/structure/trench_wall/innercorners{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = -32
+	},
+/obj/structure/trench_wall{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/structure/trench_wall/sequel{
+	dir = 6;
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/structure/closet/crate/grenade,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/room)
+"dD" = (
+/turf/simulated/wall/perspecticrete,
+/area/warfare/battlefield/trench_section/hallway)
+"dF" = (
+/obj/machinery/light/caged{
+	pixel_y = 30;
+	pixel_x = 0
+	},
+/obj/structure/trench_wall{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/structure/table/rack/shelf/red,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/room)
+"dG" = (
+/obj/hammereditor/nodraw,
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/red/room)
+"dH" = (
+/obj/structure/trench_wall/sequel{
+	dir = 4
+	},
+/obj/structure/trench_wall{
+	dir = 4
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/indoors)
+"dJ" = (
+/obj/item/storage/fancy/cigarettes,
+/obj/item/flame/lighter/random,
+/obj/machinery/light/caged{
+	pixel_y = 30;
+	pixel_x = 0
+	},
+/obj/structure/announcementspeaker/red{
+	pixel_x = 0;
+	dir = 4
+	},
+/obj/structure/table/rack/nosmooth/metal{
+	dir = 6
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/room)
+"dK" = (
+/obj/item/storage/fancy/cigarettes,
+/obj/item/flame/lighter/zippo,
+/obj/machinery/light/caged{
+	pixel_y = 30;
+	pixel_x = 0
+	},
+/obj/structure/table/rack/nosmooth/metal{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/room)
+"dL" = (
+/obj/structure/table/rack,
+/obj/structure/announcementspeaker/red{
+	id = "Bluecoats";
+	pixel_y = 32
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/stoneroom)
+"dM" = (
+/obj/effect/floor_decal/newcorner/grey/corner{
+	dir = 4
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/hallway)
+"dN" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
+	},
+/obj/effect/darkout_teleporter/bluecoats,
+/obj/effect/floor_decal/train_deco/stripes,
+/obj/effect/lighting_dummy/daylight,
+/obj/effect/landmark/train_marker/teleport/blue,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/blue/trainyard)
+"dO" = (
+/obj/structure/trench_wall{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/structure/table/rack/holorack,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/room)
+"dP" = (
+/obj/structure/trench_wall{
+	dir = 10
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"dQ" = (
+/obj/structure/toilet{
+	dir = 4;
+	icon_state = "toilet00"
+	},
+/obj/structure/trench_wall{
+	dir = 4;
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/structure/trench_wall/innercorners{
+	dir = 4;
+	pixel_x = -32;
+	pixel_y = -32
+	},
+/obj/structure/trench_wall/sequel{
+	dir = 5;
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/room)
+"dR" = (
+/obj/structure/closet/crate/wooden{
+	pixel_x = -10;
+	pixel_y = 42
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/blue/trainyard)
+"dS" = (
+/obj/structure/stairs/trenchstairs{
+	dir = 1
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"dT" = (
+/obj/machinery/door/airlock/multi_tile/metal/maintenance/red,
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/room)
+"dU" = (
+/obj/structure/railing/urban{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/dust/corner,
+/obj/effect/floor_decal/industrial/warning/dust/corner{
+	dir = 8
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/red/trainyard)
+"dV" = (
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/capture_point/blue/one)
+"dW" = (
+/obj/structure/banner/red/small{
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/trench{
+	dir = 6
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"dX" = (
+/obj/structure/stairs/trenchstairs,
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"dZ" = (
+/obj/structure/stairs/west,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/hallway)
+"ea" = (
+/obj/effect/landmark{
+	name = "tdome1"
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/space)
+"eb" = (
+/turf/unsimulated/wall/submarine/doors{
+	dir = 4
+	},
+/area/warfare/homebase/red/room)
+"ec" = (
+/obj/machinery/camera{
+	dir = 4;
+	pixel_x = 2;
+	pixel_y = 0
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/red/trainyard)
+"ed" = (
+/obj/structure/closet/crate/wooden{
+	pixel_x = -3;
+	pixel_y = 1
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/red/trainyard)
+"ee" = (
+/turf/space,
+/area/warfare/homebase/red/trainyard)
+"ef" = (
+/obj/effect/floor_decal/trench,
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"eg" = (
+/obj/machinery/camera{
+	dir = 4;
+	pixel_x = 2;
+	pixel_y = 0
+	},
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/room)
+"eh" = (
+/obj/structure/table/rack/nosmooth/metal,
+/obj/item/reagent_containers/spray/cleaner/warfare{
+	pixel_x = -4;
+	pixel_y = 0
+	},
+/obj/item/reagent_containers/spray/cleaner/warfare{
+	pixel_x = -12;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/spray/cleaner/warfare{
+	pixel_x = 4;
+	pixel_y = 0
+	},
+/obj/item/reagent_containers/spray/cleaner/warfare{
+	pixel_x = 12;
+	pixel_y = 4
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/stoneroom)
+"ei" = (
+/obj/effect/sub_marker/surface{
+	id = "SUB_END"
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/homebase/red)
+"ej" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/announcementspeaker/red{
+	pixel_x = 0;
+	dir = 4
+	},
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/hallway)
+"ek" = (
+/obj/effect/landmark/start{
+	name = "Blue Soldier"
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"el" = (
+/obj/structure/bed/chair/wheelchair,
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/stoneroom)
+"em" = (
+/obj/structure/trench_wall{
+	dir = 8;
+	pixel_x = 32
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/space)
+"en" = (
+/obj/structure/railing/urban{
+	dir = 4
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/blue/trainyard)
+"eo" = (
+/obj/effect/sub_marker/dive{
+	id = "SUB_END"
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/homebase/red)
+"ep" = (
+/obj/machinery/light/small/bunker{
+	dir = 4
+	},
+/obj/structure/soldiercryo/special/blue,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/stoneroom)
+"er" = (
+/obj/structure/toilet{
+	dir = 4;
+	icon_state = "toilet00"
+	},
+/obj/machinery/light/small/bunker{
+	dir = 8
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/room)
+"et" = (
+/obj/machinery/vending/medical{
+	req_access = newlist()
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"eu" = (
+/obj/machinery/door/airlock/multi_tile/metal/maintenance{
+	dir = 1;
+	icon_state = "door_closed";
+	name = "Emergency Medical"
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/stoneroom)
+"ev" = (
+/obj/hammereditor/nodraw/deco/bars{
+	dir = 8
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/hallway)
+"ew" = (
+/obj/machinery/door/airlock/bunker/red,
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/hallway)
+"ex" = (
+/obj/structure/table/rack/holorack,
+/obj/machinery/light/small/bunker{
+	dir = 1
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"ey" = (
+/obj/machinery/body_scanconsole{
+	dir = 4;
+	icon_state = "body_scannerconsole"
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"ez" = (
+/turf/unsimulated/wall/hammereditor/dev1,
+/area/warfare/homebase/blue)
+"eA" = (
+/obj/structure/trench_wall{
+	dir = 8
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/indoors)
+"eB" = (
+/obj/effect/darkout_teleporter/bluecoats,
+/obj/effect/floor_decal/industrial/warning/dust,
+/obj/effect/landmark/train_marker/teleport/red,
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/red/trainyard)
+"eD" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/hallway)
+"eF" = (
+/obj/hammereditor/nodraw/deco/bars{
+	dir = 4
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/hallway)
+"eG" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
+"eI" = (
+/obj/structure/stairs/west{
+	dir = 4
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/hallway)
+"eJ" = (
+/turf/simulated/floor/tiled/ramp{
+	dir = 4;
+	icon_state = "ramptop"
+	},
+/area/warfare/homebase/blue/hallway)
+"eK" = (
+/turf/simulated/open,
+/area/warfare/homebase/blue/hallway)
+"eL" = (
+/obj/effect/floor_decal/newcorner/grey/corner,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/hallway)
+"eN" = (
+/obj/machinery/door/airlock/multi_tile/metal/maintenance/blue,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/hallway)
+"eO" = (
+/obj/structure/trench_wall{
+	dir = 8
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/room)
+"eP" = (
+/obj/structure/poster/blue{
+	pixel_y = 32
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"eR" = (
+/obj/structure/trench_wall{
+	dir = 10
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/red/one)
+"eS" = (
+/obj/structure/trench_wall{
+	dir = 8
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"eW" = (
+/obj/item/device/compass,
+/obj/structure/table/rack/nosmooth/wood/alt,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"eX" = (
+/obj/structure/trench_wall{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/structure/table/rack/holorack,
+/obj/machinery/light/caged{
+	pixel_y = 30;
+	pixel_x = 0
+	},
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/room)
+"eY" = (
+/obj/structure/announcementspeaker/red{
+	pixel_x = 0;
+	dir = 4
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"fa" = (
+/obj/effect/landmark/start{
+	name = "Blue Soldier"
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/largeroom)
+"fb" = (
+/obj/effect/landmark/start{
+	name = "Blue Scavenger"
+	},
+/obj/structure/toilet{
+	dir = 8;
+	icon_state = "toilet00"
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/room)
+"fc" = (
+/obj/effect/landmark/start{
+	name = "Blue Soldier"
+	},
+/obj/structure/toilet{
+	dir = 8;
+	icon_state = "toilet00"
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/room)
+"fe" = (
+/obj/structure/poster/blue,
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/blue/room)
+"fi" = (
+/obj/effect/landmark/start{
+	name = "Blue Soldier"
+	},
+/obj/structure/bed/chair/blue{
+	dir = 4
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"fj" = (
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 6
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"fk" = (
+/obj/effect/landmark/start{
+	name = "Blue Soldier"
+	},
+/obj/machinery/light/small/bunker{
+	dir = 4
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"fo" = (
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 5
+	},
+/obj/item/storage/box/matches{
+	pixel_x = 7;
+	pixel_y = 10
+	},
+/obj/item/flame/lighter/random{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/wirecutters{
+	pixel_x = 17;
+	pixel_y = 1
+	},
+/obj/item/storage/fancy/cigarettes/carcinomas{
+	pixel_x = -11;
+	pixel_y = 14
+	},
+/obj/item/storage/fancy/cigarettes{
+	pixel_x = 18;
+	pixel_y = 13
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"fp" = (
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/toxin,
+/obj/structure/table/rack/shelf/red,
+/obj/structure/announcementspeaker/red{
+	pixel_x = 0;
+	dir = 4
+	},
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/room)
+"fq" = (
+/obj/machinery/door/airlock/multi_tile/metal/maintenance{
+	dir = 1;
+	icon_state = "door_closed";
+	name = "Emergency Medical"
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"fr" = (
+/obj/effect/landmark/start{
+	name = "Blue Soldier"
+	},
+/obj/structure/bed/chair/blue{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 11;
+	buckle_pixel_shift = "x=0;y=11"
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"ft" = (
+/obj/effect/landmark/start{
+	name = "Blue Engineer"
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"fv" = (
+/obj/structure/curtain/medical{
+	color = "#b8dddddd"
+	},
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/stoneroom)
+"fw" = (
+/obj/effect/landmark/start{
+	name = "Blue Squad Leader"
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"fx" = (
+/obj/item/device/compass,
+/obj/item/device/compass,
+/obj/item/device/compass,
+/obj/item/device/compass,
+/obj/item/device/compass,
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 4
+	},
+/obj/item/flame/candle/blue,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"fy" = (
+/obj/item/storage/fancy/cigarettes/carcinomas,
+/obj/item/device/cassette/tape3,
+/obj/structure/table/rack/nosmooth/wood{
+	dir = 6
+	},
+/obj/machinery/light/small/bunker{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/item/flame/candle/blue,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"fz" = (
+/obj/structure/safe/floor,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/hallway)
+"fA" = (
+/obj/item/storage/box/matches,
+/obj/item/device/cassette/tape1,
+/obj/item/device/cassette/tape2,
+/obj/structure/table/rack/nosmooth/wood{
+	dir = 10
+	},
+/obj/item/flame/candle/blue,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"fB" = (
+/obj/effect/landmark/start{
+	name = "Blue Sniper"
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"fC" = (
+/obj/effect/landmark/start{
+	name = "Blue Sentry"
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"fD" = (
+/obj/structure/barbwire,
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/battlefield/capture_point/blue/one)
+"fE" = (
+/obj/structure/closet/crate{
+	name = "gasmask crate"
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"fG" = (
+/obj/machinery/button/remote/blast_door/lever{
+	id = "blue";
+	pixel_x = -1;
+	pixel_y = -32
+	},
+/obj/structure/announcementspeaker/blue{
+	pixel_x = 0;
+	dir = 1
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"fH" = (
+/obj/item/storage/fancy/cigarettes/jerichos,
+/obj/item/flame/lighter/random,
+/obj/item/device/boombox,
+/obj/structure/table/rack/nosmooth/wood{
+	dir = 5
+	},
+/obj/machinery/light/small/bunker{
+	dir = 1
+	},
+/obj/item/flame/candle/blue,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"fI" = (
+/obj/machinery/button/remote/blast_door/lever{
+	id = "blue";
+	pixel_x = -32
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/hallway)
+"fJ" = (
+/obj/effect/landmark/start{
+	name = "Blue Soldier"
+	},
+/obj/machinery/button/remote/blast_door/lever{
+	id = "blue";
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/structure/announcementspeaker/blue{
+	pixel_x = 0;
+	dir = 1
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"fK" = (
+/obj/effect/landmark/start{
+	name = "Blue Flame Trooper"
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"fL" = (
+/obj/effect/landmark/start{
+	name = "Red Soldier"
+	},
+/obj/structure/bed/chair/red,
+/obj/machinery/light/caged{
+	pixel_y = 30;
+	pixel_x = -16
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"fM" = (
+/obj/structure/barbwire,
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/battlefield/capture_point/blue/two)
+"fN" = (
+/obj/structure/dirt_wall,
+/obj/machinery/door/blast/shutters/open{
+	id = "blue"
+	},
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/homebase/blue/largeroom)
+"fO" = (
+/obj/machinery/door/blast/shutters/open{
+	id = "blue"
+	},
+/obj/machinery/door/airlock/multi_tile/metal/maintenance/blue,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/hallway)
+"fP" = (
+/obj/machinery/door/blast/shutters/open{
+	id = "blue"
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/hallway)
+"fQ" = (
+/obj/structure/closet/crate/trashcart,
+/turf/simulated/floor/trenches,
+/area/warfare/homebase/blue)
+"fR" = (
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/homebase/blue)
+"fS" = (
+/obj/structure/banner/blue{
+	pixel_y = 32
+	},
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/homebase/blue)
+"fT" = (
+/obj/structure/banner/blue{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/homebase/blue)
+"fU" = (
+/obj/structure/poster/blue,
+/obj/hammereditor/nodraw,
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/blue/room)
+"fV" = (
+/obj/structure/closet/crate{
+	name = "gasmask crate"
+	},
+/obj/item/clothing/mask/gas/blue,
+/obj/item/clothing/mask/gas/blue,
+/obj/item/clothing/mask/gas/blue,
+/obj/item/clothing/mask/gas/blue,
+/obj/item/clothing/mask/gas/blue,
+/obj/item/clothing/mask/gas/blue,
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue)
+"fW" = (
+/obj/structure/dirt_wall,
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/homebase/blue)
+"fX" = (
+/obj/structure/barbwire,
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/homebase/blue)
+"fY" = (
+/turf/simulated/floor/dirty/tough,
+/area/warfare/homebase/blue)
+"fZ" = (
+/obj/structure/closet/crate,
+/obj/item/crowbar,
+/obj/item/crowbar,
+/obj/item/crowbar,
+/obj/item/plastique/blue,
+/obj/item/plastique/blue,
+/obj/item/plastique/blue,
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue)
+"gb" = (
+/turf/simulated/floor/dirty/tough,
+/area/warfare/battlefield/capture_point/blue/two)
+"gc" = (
+/obj/structure/dirt_wall,
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/battlefield/capture_point/blue/two)
+"gd" = (
+/turf/simulated/floor/trench,
+/area/warfare/battlefield/capture_point/blue/two)
+"ge" = (
+/turf/simulated/open,
+/area/warfare/battlefield/capture_point/blue/two)
+"gf" = (
+/obj/effect/floor_decal/newcorner/grey/corner,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/hallway)
+"gg" = (
+/obj/hammereditor/nodraw,
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/blue/room)
+"gh" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/hallway)
+"gi" = (
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/battlefield/capture_point/blue/two)
+"gj" = (
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/battlefield/trench_section)
+"gk" = (
+/obj/structure/dirt_wall,
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/battlefield/trench_section)
+"gl" = (
+/obj/structure/barbwire,
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/battlefield/trench_section)
+"gm" = (
+/turf/simulated/open,
+/area/warfare/battlefield/capture_point/blue/one)
+"gn" = (
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/battlefield/capture_point/blue/one)
+"go" = (
+/obj/structure/dirt_wall,
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/battlefield/capture_point/blue/one)
+"gp" = (
+/turf/simulated/floor/trench,
+/area/warfare/battlefield/capture_point/blue/one)
+"gq" = (
+/turf/simulated/floor/dirty/fake,
+/area/warfare/battlefield/capture_point/blue/one)
+"gr" = (
+/obj/structure/barbwire,
+/turf/simulated/floor/dirty/fake,
+/area/warfare/battlefield/capture_point/blue/one)
+"gv" = (
+/obj/machinery/light/caged{
+	dir = 8;
+	pixel_x = 10;
+	pixel_y = 0
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/trench_section/underground)
+"gw" = (
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 14;
+	pixel_y = 8
+	},
+/obj/item/crowbar/prybar{
+	pixel_x = 3;
+	pixel_y = 13
+	},
+/obj/item/screwdriver{
+	pixel_x = 8
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/room)
+"gx" = (
+/turf/simulated/floor,
+/area/warfare/battlefield/no_mans_land)
+"gA" = (
+/obj/structure/barbwire,
+/turf/simulated/floor/dirty/fake,
+/area/warfare/battlefield/capture_point/red/one)
+"gB" = (
+/turf/simulated/floor/dirty/fake,
+/area/warfare/battlefield/capture_point/red/one)
+"gC" = (
+/obj/structure/dirt_wall,
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/battlefield/capture_point/red/one)
+"gD" = (
+/turf/simulated/floor/trench,
+/area/warfare/battlefield/capture_point/red/one)
+"gE" = (
+/turf/simulated/open,
+/area/warfare/battlefield/capture_point/red/one)
+"gF" = (
+/obj/item/storage/belt/medical/full,
+/obj/item/storage/belt/medical/full,
+/obj/item/storage/belt/medical/full,
+/obj/item/storage/belt/medical/full,
+/obj/item/storage/belt/medical/full,
+/obj/machinery/light/caged{
+	pixel_y = 30;
+	pixel_x = 0
+	},
+/obj/structure/trench_wall/innercorners{
+	dir = 1;
+	pixel_x = 32;
+	pixel_y = 31
+	},
+/obj/structure/trench_wall{
+	dir = 5;
+	pixel_x = 32;
+	layer = 28
+	},
+/obj/structure/table/rack/shelf/red,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"gG" = (
+/turf/simulated/open,
+/area/warfare/battlefield/capture_point/red/two)
+"gH" = (
+/obj/structure/cargo_pad/blue,
+/obj/structure/window/reinforced{
+	dir = 4;
+	icon_state = "rwindow"
+	},
+/obj/machinery/light/small/bunker{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/room)
+"gI" = (
+/obj/structure/trench_wall{
+	dir = 5;
+	pixel_x = 32;
+	layer = 28
+	},
+/obj/structure/trench_wall/innercorners{
+	dir = 1;
+	pixel_x = 32;
+	pixel_y = 31
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"gJ" = (
+/obj/structure/dirt_wall,
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/battlefield/capture_point/red/two)
+"gL" = (
+/turf/simulated/floor/trench,
+/area/warfare/battlefield/capture_point/red/two)
+"gM" = (
+/turf/simulated/floor/dirty/tough,
+/area/warfare/battlefield/capture_point/red/two)
+"gN" = (
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red)
+"gO" = (
+/turf/simulated/floor/dirty/tough,
+/area/warfare/homebase/red)
+"gP" = (
+/obj/structure/closet/crate,
+/obj/item/crowbar,
+/obj/item/crowbar,
+/obj/item/crowbar,
+/obj/item/plastique/red,
+/obj/item/plastique/red,
+/obj/item/plastique/red,
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red)
+"gQ" = (
+/obj/structure/barbwire,
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/homebase/red)
+"gR" = (
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/homebase/red)
+"gS" = (
+/obj/structure/dirt_wall,
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/homebase/red)
+"gT" = (
+/obj/structure/closet/crate/trashcart,
+/turf/simulated/floor/trenches,
+/area/warfare/homebase/red)
+"gW" = (
+/obj/structure/banner/red{
+	pixel_y = -32;
+	pixel_z = 0
+	},
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/homebase/red)
+"gX" = (
+/obj/structure/banner/red{
+	pixel_y = -32
+	},
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/homebase/red)
+"gY" = (
+/obj/structure/dirt_wall,
+/obj/machinery/door/blast/shutters/open{
+	id = "red"
+	},
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/homebase/red/largeroom)
+"gZ" = (
+/obj/machinery/door/blast/shutters/open{
+	id = "red"
+	},
+/obj/machinery/door/airlock/multi_tile/metal/maintenance/red,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/hallway)
+"ha" = (
+/obj/machinery/door/blast/shutters/open{
+	id = "red"
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/hallway)
+"hc" = (
+/obj/structure/train_deco/tracks01,
+/turf/simulated/floor/urban/destroyed,
+/area/warfare/homebase/blue/trainyard)
+"hd" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning/dust,
+/obj/effect/lighting_dummy/daylight,
+/obj/effect/landmark/train_marker/teleport/red,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/red/trainyard)
+"he" = (
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/space)
+"hf" = (
+/obj/hammereditor/nodraw/deco/shadowpaint{
+	opacity = 1;
+	dir = 8
+	},
+/obj/hammereditor/nodraw/deco/shadowpaint{
+	opacity = 1;
+	dir = 1
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/trainyard)
+"hg" = (
+/obj/item/storage/fancy/cigarettes,
+/obj/item/flame/candle,
+/obj/item/flame/lighter/random,
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 5
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"hh" = (
+/obj/structure/trench_wall{
+	dir = 5;
+	layer = 28
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/indoors)
+"hi" = (
+/obj/effect/landmark/start{
+	name = "Blue Soldier"
+	},
+/obj/structure/bed/chair/blue,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"hj" = (
+/obj/machinery/door/airlock/multi_tile/metal/maintenance/blue,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/stoneroom)
+"hk" = (
+/obj/structure/closet/crate/wooden/large{
+	icon_closed = "meatball";
+	icon_state = "meatball";
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/blue/trainyard)
+"hl" = (
+/obj/machinery/button/remote/blast_door/lever{
+	id = "red";
+	pixel_x = -32
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/hallway)
+"hn" = (
+/obj/effect/landmark/start{
+	name = "Red Soldier"
+	},
+/obj/machinery/button/remote/blast_door/lever{
+	id = "red";
+	pixel_y = 32
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"ho" = (
+/obj/effect/landmark/start{
+	name = "Red Engineer"
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"hp" = (
+/obj/effect/landmark/start{
+	name = "Red Sniper"
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"hq" = (
+/obj/effect/floor_decal/trench{
+	dir = 4
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/two)
+"ht" = (
+/obj/effect/landmark/start{
+	name = "Red Flame Trooper"
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"hv" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"hw" = (
+/obj/effect/floor_decal/trench{
+	dir = 10
+	},
+/obj/machinery/light/caged{
+	pixel_y = -1;
+	dir = 1;
+	pixel_x = 0
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/one)
+"hx" = (
+/obj/effect/landmark/start{
+	name = "Red Sentry"
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"hy" = (
+/obj/effect/landmark/start{
+	name = "Red Soldier"
+	},
+/obj/structure/bed/chair/red{
+	dir = 4;
+	pixel_x = 6;
+	pixel_y = 0;
+	buckle_pixel_shift = "x=6;y=0"
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"hz" = (
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 8
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"hA" = (
+/obj/effect/landmark/start{
+	name = "Red Soldier"
+	},
+/obj/structure/bed/chair/red{
+	dir = 8;
+	pixel_x = -6;
+	pixel_y = 0;
+	buckle_pixel_shift = "x=-6;y=0"
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"hB" = (
+/obj/structure/trench_wall/sequel{
+	dir = 4
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground)
+"hC" = (
+/obj/item/flame/candle,
+/obj/item/device/compass,
+/obj/item/device/compass,
+/obj/item/device/compass,
+/obj/item/device/compass,
+/obj/item/device/compass,
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 4
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"hH" = (
+/obj/effect/floor_decal/urban/trim1,
+/obj/effect/floor_decal/urban/trim1{
+	dir = 1
+	},
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"hI" = (
+/obj/effect/floor_decal/trench{
+	dir = 10
+	},
+/obj/structure/stairs/trenchstairs,
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"hJ" = (
+/obj/machinery/door/airlock/multi_tile/metal/maintenance{
+	dir = 1;
+	icon_state = "door_closed";
+	name = "Emergency Medical"
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/stoneroom)
+"hL" = (
+/obj/structure/closet/crate/medical,
+/obj/item/wirecutters,
+/obj/item/wirecutters,
+/obj/item/storage/firstaid/regular,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"hM" = (
+/obj/structure/closet/crate/medical,
+/obj/item/wirecutters,
+/obj/item/storage/firstaid/regular,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"hN" = (
+/obj/machinery/door/airlock/multi_tile/metal/maintenance/red,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/room)
+"hO" = (
+/obj/hammereditor/nodraw,
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/blue/hallway)
+"hP" = (
+/obj/machinery/light,
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/stoneroom)
+"hQ" = (
+/obj/item/device/compass,
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 6
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"hR" = (
+/obj/item/flame/candle,
+/obj/item/storage/fancy/cigarettes/carcinomas,
+/obj/item/device/cassette/tape3,
+/obj/structure/table/rack/nosmooth/wood{
+	dir = 6
+	},
+/obj/machinery/light/small/bunker{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"hS" = (
+/obj/item/flame/candle,
+/obj/item/storage/box/matches,
+/obj/item/device/cassette/tape1,
+/obj/item/device/cassette/tape2,
+/obj/structure/table/rack/nosmooth/wood{
+	dir = 10
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"hU" = (
+/obj/machinery/shower{
+	dir = 8;
+	icon_state = "shower"
+	},
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/room)
+"hV" = (
+/obj/effect/landmark/start{
+	name = "Red Bartender"
+	},
+/obj/structure/toilet{
+	dir = 4;
+	icon_state = "toilet00"
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/room)
+"hW" = (
+/obj/item/storage/fancy/cigarettes/jerichos,
+/obj/item/flame/candle,
+/obj/item/flame/lighter/random,
+/obj/item/device/boombox,
+/obj/structure/table/rack/nosmooth/wood{
+	dir = 5
+	},
+/obj/machinery/light/small/bunker{
+	dir = 1
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"hZ" = (
+/obj/structure/defensive_barrier{
+	secured = 1;
+	dir = 4;
+	pixel_x = 2;
+	pixel_y = 1
+	},
+/obj/hammereditor/nodraw,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/hallway)
+"ia" = (
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/trainyard)
+"ib" = (
+/obj/effect/darkout_teleporter/bluecoats,
+/obj/effect/floor_decal/train_deco/stripes{
+	pixel_y = 11
+	},
+/obj/effect/floor_decal/industrial/warning/dust,
+/obj/effect/landmark/train_marker/teleport/red,
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/red/trainyard)
+"ic" = (
+/obj/structure/bed/chair/wheelchair,
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/stoneroom)
+"id" = (
+/turf/simulated/floor/tiled/ramp{
+	dir = 4;
+	icon_state = "ramptop"
+	},
+/area/warfare/homebase/red/hallway)
+"ie" = (
+/turf/simulated/open,
+/area/warfare/homebase/red/hallway)
+"if" = (
+/obj/effect/landmark/start{
+	name = "Red Practitioner"
+	},
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/stoneroom)
+"ig" = (
+/obj/effect/lighting_dummy/daylight,
+/obj/effect/landmark{
+	name = "Observer-Start"
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section)
+"ih" = (
+/obj/structure/table/rack/nosmooth/metal,
+/obj/structure/curtain,
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/stoneroom)
+"ii" = (
+/turf/simulated/floor/tiled/ramp{
+	dir = 8;
+	icon_state = "ramptop"
+	},
+/area/warfare/homebase/red/stoneroom)
+"ij" = (
+/obj/structure/table/rack/nosmooth/metal,
+/obj/item/storage/firstaid/surgery,
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/room)
+"ik" = (
+/obj/structure/trench_wall/sequel{
+	dir = 4
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/blue/two)
+"il" = (
+/obj/effect/floor_decal/industrial/warning/dust/corner,
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/red/trainyard)
+"im" = (
+/obj/effect/landmark{
+	name = "JoinLate"
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/homebase/red)
+"in" = (
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/red/trainyard)
+"io" = (
+/obj/structure/bed/roller,
+/obj/structure/curtain,
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/stoneroom)
+"ip" = (
+/obj/structure/curtain/medical{
+	color = "#b8dddddd"
+	},
+/obj/structure/bed/roller,
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/stoneroom)
+"iq" = (
+/obj/effect/landmark/test/space_turf,
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/homebase/red)
+"ir" = (
+/obj/structure/train_deco/tracks01,
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/trainyard)
+"it" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/announcementspeaker/red{
+	pixel_x = 0;
+	dir = 4
+	},
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/room)
+"iu" = (
+/obj/machinery/body_scanconsole{
+	dir = 4;
+	icon_state = "body_scannerconsole"
+	},
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/room)
+"iv" = (
+/obj/machinery/bodyscanner{
+	dir = 4;
+	icon_state = "body_scanner_0"
+	},
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/room)
+"ix" = (
+/obj/hammereditor/nodraw/deco/shadowpaint{
+	opacity = 1;
+	dir = 8
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/trainyard)
+"iy" = (
+/obj/structure/stairs/west{
+	dir = 4
+	},
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/stoneroom)
+"iA" = (
+/turf/simulated/open,
+/area/warfare/homebase/red/stoneroom)
+"iB" = (
+/obj/machinery/light,
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/stoneroom)
+"iD" = (
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/room)
+"iE" = (
+/obj/effect/landmark/map_data{
+	height = 2
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/homebase/red)
+"iK" = (
+/obj/item/storage/toggle/envelope{
+	pixel_x = 0;
+	pixel_y = 5
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = 8;
+	pixel_y = 5
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = 0;
+	pixel_y = 3
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = 8;
+	pixel_y = 3
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = -8;
+	pixel_y = 1
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = 0;
+	pixel_y = 1
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = 8;
+	pixel_y = 1
+	},
+/obj/structure/table/nosmooth/capnew{
+	pixel_y = -4;
+	dir = 8
+	},
+/obj/structure/table/nosmooth/capnew{
+	pixel_y = 28;
+	dir = 9;
+	pixel_x = 0
+	},
+/obj/item/storage/box/matches{
+	pixel_x = 0;
+	pixel_y = 17
+	},
+/obj/structure/window/reinforced{
+	pixel_x = 0;
+	pixel_y = 7
+	},
+/obj/item/flame/candle/blue{
+	pixel_x = -11;
+	pixel_y = 20
+	},
+/obj/item/flame/candle/blue{
+	pixel_x = -9;
+	pixel_y = 20
+	},
+/obj/item/flame/candle/blue{
+	pixel_x = -7;
+	pixel_y = 20
+	},
+/obj/item/waxstamp/blue{
+	pixel_x = -10;
+	pixel_y = 16
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/largeroom)
+"iQ" = (
+/obj/structure/closet/crate,
+/obj/machinery/light/small/bunker{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/random/canned_food/red,
+/obj/random/canned_food/red,
+/obj/structure/announcementspeaker/red{
+	id = "Bluecoats";
+	dir = 4
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"iS" = (
+/turf/unsimulated/wall/hammereditor/dev1,
+/area/warfare/homebase/blue/div)
+"iU" = (
+/obj/machinery/light/caged{
+	dir = 4;
+	pixel_x = -10;
+	pixel_y = 0
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"iV" = (
+/obj/effect/floor_decal/trench{
+	dir = 6
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/trench_section/underground)
+"iX" = (
+/obj/structure/closet/crate/wooden/large,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
+"iZ" = (
+/obj/structure/closet/body_bag,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"jc" = (
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"jh" = (
+/obj/structure/soldiercryo/special/blue,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/stoneroom)
+"jj" = (
+/obj/effect/landmark/start{
+	name = "Red Soldier"
+	},
+/obj/machinery/light/small/bunker{
+	dir = 4
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"jo" = (
+/obj/machinery/light/small/bunker{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/warfare/homebase/blue/caproom)
+"jq" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 4
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/blue/trainyard)
+"jr" = (
+/obj/machinery/light/small/bunker{
+	dir = 4
+	},
+/obj/structure/table/rack/shelf/red,
+/obj/item/device/cassette/greed1,
+/obj/item/device/cassette/greed2,
+/obj/item/device/cassette/greed3,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/largeroom)
+"js" = (
+/obj/hammereditor/nodraw/deco/shadowpaint{
+	opacity = 1;
+	dir = 8
+	},
+/obj/structure/train_deco/tracks01,
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/trainyard)
+"ju" = (
+/obj/random/canned_food/red,
+/obj/random/canned_food/red,
+/obj/structure/table/rack/shelf/red,
+/obj/random/canned_food/red,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/room)
+"jv" = (
+/obj/machinery/light/small/red{
+	dir = 1;
+	pixel_y = 15
+	},
+/obj/structure/closet/body_bag,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"jy" = (
+/obj/structure/trench_wall/sequel{
+	dir = 1
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/indoors)
+"jz" = (
+/obj/structure/announcementspeaker/red{
+	pixel_x = 0;
+	dir = 1
+	},
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/battlefield/trench_section)
+"jA" = (
+/obj/machinery/door/airlock/multi_tile/metal/maintenance{
+	dir = 1;
+	icon_state = "door_closed";
+	name = "Emergency Medical"
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"jC" = (
+/obj/effect/floor_decal/stones{
+	dir = 1
+	},
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/battlefield/capture_point/blue/one)
+"jD" = (
+/obj/machinery/door/airlock/multi_tile/metal/maintenance/red,
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/hallway)
+"jO" = (
+/obj/structure/curtain/tarp{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"jP" = (
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/red/hallway)
+"jT" = (
+/obj/structure/table/rack/holorack,
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/room)
+"jW" = (
+/obj/structure/trench_wall/sequel{
+	dir = 4
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"jZ" = (
+/obj/item/storage/belt/medical/full,
+/obj/item/storage/belt/medical/full,
+/obj/item/storage/belt/medical/full,
+/obj/item/storage/belt/medical/full,
+/obj/item/storage/belt/medical/full,
+/obj/machinery/light/caged{
+	pixel_y = 30;
+	pixel_x = 0
+	},
+/obj/structure/trench_wall/innercorners{
+	pixel_x = -32;
+	pixel_y = 31
+	},
+/obj/structure/trench_wall{
+	dir = 5;
+	pixel_x = -32;
+	layer = 28
+	},
+/obj/structure/table/rack/shelf/red,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"kb" = (
+/obj/structure/trench_wall/innercorners{
+	dir = 1
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/room)
+"ke" = (
+/obj/structure/closet/crate,
+/obj/random/canned_food/blue,
+/obj/random/canned_food/blue,
+/obj/structure/table/rack/holorack,
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/room)
+"kl" = (
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/hallway)
+"km" = (
+/obj/structure/train_deco/tracks01,
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/trainyard)
+"kq" = (
+/obj/structure/table/rack,
+/obj/item/storage/box/bodybags,
+/obj/item/storage/box/bodybags,
+/obj/item/storage/box/bodybags,
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/stoneroom)
+"ks" = (
+/obj/structure/trench_wall/innercorners{
+	dir = 4
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/space)
+"kw" = (
+/obj/machinery/computer/operating{
+	dir = 1;
+	density = 1;
+	icon_state = "console"
+	},
+/obj/machinery/light/caged{
+	dir = 1;
+	pixel_y = -1
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"kz" = (
+/obj/machinery/light/caged{
+	pixel_y = 30;
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/trench,
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"kG" = (
+/obj/effect/landmark/start{
+	name = "Blue Sentry"
+	},
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"kK" = (
+/turf/simulated/floor/wood,
+/area/warfare/homebase/red/caproom)
+"kR" = (
+/obj/effect/floor_decal/industrial/direction{
+	dir = 4
+	},
+/obj/structure/sign/neon/armory{
+	pixel_y = 32
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/hallway)
+"kS" = (
+/obj/structure/toilet{
+	dir = 8;
+	icon_state = "toilet00"
+	},
+/obj/structure/trench_wall{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/room)
+"kY" = (
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/item/wrench{
+	pixel_x = -15;
+	pixel_y = 5
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/room)
+"kZ" = (
+/obj/machinery/door/airlock/multi_tile/metal/maintenance/blue,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/room)
+"la" = (
+/obj/machinery/light/caged{
+	dir = 4;
+	pixel_x = -1;
+	pixel_y = 0
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"lc" = (
+/obj/structure/closet/crate,
+/obj/random/canned_food/blue,
+/obj/random/canned_food/blue,
+/obj/structure/announcementspeaker/blue{
+	pixel_y = 0;
+	dir = 4
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"le" = (
+/obj/machinery/door/airlock/multi_tile/metal/maintenance/red,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/hallway)
+"lf" = (
+/obj/structure/trench_wall{
+	dir = 1
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"lh" = (
+/obj/structure/announcementspeaker/red{
+	pixel_x = 0;
+	dir = 1
+	},
+/turf/simulated/open,
+/area/warfare/battlefield/capture_point/red/one)
+"li" = (
+/obj/machinery/light/small/bunker{
+	dir = 8
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"ll" = (
+/obj/effect/landmark/start/redcoats,
+/obj/structure/bed/chair/gray{
+	dir = 1
+	},
+/turf/simulated/floor/ert/metal01,
+/area/train/red)
+"ls" = (
+/obj/structure/trench_wall{
+	dir = 4
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"lu" = (
+/obj/machinery/door/airlock/multi_tile/metal/maintenance/blue,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/blue/hallway)
+"lw" = (
+/obj/hammereditor/nodraw/deco/shutter_quarter{
+	dir = 1
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/room)
+"lx" = (
+/obj/effect/landmark/start{
+	name = "Red Soldier"
+	},
+/obj/structure/bed/chair/red{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 11;
+	buckle_pixel_shift = "x=0;y=11"
+	},
+/obj/machinery/light/small/bunker{
+	dir = 8
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"ly" = (
+/obj/structure/trench_wall/innercorners{
+	dir = 8
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"lB" = (
+/obj/effect/floor_decal/trench{
+	dir = 4
+	},
+/obj/machinery/light/caged{
+	pixel_y = -1;
+	dir = 1;
+	pixel_x = 0
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/one)
+"lE" = (
+/obj/machinery/light/small/bunker{
+	dir = 1
+	},
+/obj/machinery/telecomms/allinone{
+	intercept = 1
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"lI" = (
+/obj/structure/trench_wall/innercorners{
+	dir = 1;
+	pixel_x = 32;
+	pixel_y = 31
+	},
+/obj/structure/trench_wall{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/structure/stairs/trenchstairs{
+	dir = 1
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"lK" = (
+/obj/structure/bed/chair/blue{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 11;
+	buckle_pixel_shift = "x=0;y=11"
+	},
+/obj/effect/landmark/start{
+	name = "Red Soldier"
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/largeroom)
+"lL" = (
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/room)
+"lN" = (
+/obj/structure/announcementspeaker/red{
+	pixel_x = 0;
+	dir = 4
+	},
+/obj/machinery/light/small/bunker{
+	dir = 1
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/hallway)
+"lO" = (
+/obj/structure/trench_wall{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/structure/trench_wall/innercorners{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = -32
+	},
+/obj/structure/trench_wall{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/structure/trench_wall/sequel{
+	dir = 6;
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/structure/closet/crate,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/room)
+"lV" = (
+/obj/structure/poster/red,
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/red/hallway)
+"lX" = (
+/obj/structure/table/rack/nosmooth/metal,
+/obj/item/storage/box/bodybags{
+	pixel_x = 0;
+	pixel_y = 11
+	},
+/obj/item/storage/box/bodybags{
+	pixel_x = 0;
+	pixel_y = -1
+	},
+/obj/machinery/light/caged{
+	pixel_y = 30;
+	pixel_x = 16
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"ma" = (
+/obj/machinery/sleeper{
+	dir = 4;
+	icon_state = "sleeper_0"
+	},
+/obj/structure/announcementspeaker/red{
+	id = "Bluecoats";
+	pixel_y = 32
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"mc" = (
+/obj/machinery/light/small/bunker{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/stoneroom)
+"mf" = (
+/obj/effect/landmark/start{
+	name = "Red Soldier"
+	},
+/obj/structure/bed/chair/red,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"mi" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	icon_state = "rwindow"
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/room)
+"ml" = (
+/obj/machinery/light/caged{
+	pixel_y = -14;
+	dir = 1;
+	pixel_x = 0
+	},
+/obj/item/device/compass,
+/obj/item/device/compass,
+/obj/structure/table/rack/nosmooth/wood,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/room)
+"mo" = (
+/obj/structure/table/rack/holorack,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"ms" = (
+/obj/effect/landmark/start{
+	name = "Blue Practitioner"
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"mu" = (
+/obj/structure/table/rack,
+/obj/item/storage/box/bodybags,
+/obj/item/storage/box/bodybags,
+/obj/item/storage/box/bodybags,
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/stoneroom)
+"mw" = (
+/turf/simulated/floor/wood,
+/area/warfare/homebase/blue)
+"mD" = (
+/obj/structure/trench_wall{
+	dir = 1
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/red/one)
+"mJ" = (
+/obj/structure/table/rack/shelf/red,
+/obj/machinery/light/small/bunker{
+	dir = 1
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"mL" = (
+/obj/effect/lighting_dummy/daylight,
+/obj/structure/train_deco/tracks01,
+/obj/hammereditor/playerclip,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/trainyard)
+"mN" = (
+/obj/machinery/light/caged{
+	dir = 4;
+	pixel_x = -10;
+	pixel_y = 0
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"mQ" = (
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 8
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"mT" = (
+/obj/effect/floor_decal/trench{
+	dir = 1
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/two)
+"mU" = (
+/obj/structure/closet/secure_closet/medical1/warfare,
+/obj/item/clothing/suit/surgeon_apron,
+/obj/item/clothing/suit/surgeon_apron,
+/obj/item/clothing/suit/surgeon_apron,
+/obj/item/clothing/suit/surgeon_apron,
+/obj/item/storage/backpack/satchel/warfare/prac/blue,
+/obj/item/storage/backpack/satchel/warfare/prac/blue,
+/obj/structure/announcementspeaker/red{
+	id = "Bluecoats";
+	pixel_y = 32
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"mX" = (
+/obj/structure/table/rack/nosmooth/metal,
+/obj/item/storage/box/bodybags{
+	pixel_x = 0;
+	pixel_y = 11
+	},
+/obj/item/storage/box/bodybags{
+	pixel_x = 0;
+	pixel_y = -1
+	},
+/obj/machinery/light/caged{
+	pixel_y = 30;
+	pixel_x = 16
+	},
+/obj/structure/trench_wall/innercorners{
+	pixel_y = 32;
+	pixel_x = -32
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"mZ" = (
+/obj/structure/warfare_itemeater/red{
+	pixel_y = 32
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"nb" = (
+/obj/structure/curtain,
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/room)
+"nc" = (
+/obj/structure/lattice,
+/obj/machinery/light/caged{
+	dir = 4;
+	pixel_x = -10;
+	pixel_y = 0
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/underground)
+"ne" = (
+/obj/effect/landmark/start/redcoats,
+/obj/structure/bed/chair/gray,
+/turf/simulated/floor/ert/metal01,
+/area/train/red)
+"ng" = (
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/red/trainyard)
+"ni" = (
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/structure/table/rack/shelf/red,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"nm" = (
+/turf/simulated/mineral{
+	health = 999999
+	},
+/turf/simulated/open,
+/area/space)
+"nn" = (
+/obj/machinery/light/caged{
+	pixel_y = 30;
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/trench,
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/two)
+"nq" = (
+/obj/effect/phone_line,
+/obj/item/paper_bin{
+	pixel_x = 4;
+	pixel_y = 10
+	},
+/obj/structure/table/nosmooth/capnew{
+	pixel_y = -4;
+	dir = 4
+	},
+/obj/item/pen/blue{
+	pixel_x = 2;
+	pixel_y = 10
+	},
+/obj/item/storage/fancy/cigar{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/structure/table/nosmooth/capnew{
+	pixel_y = 28;
+	dir = 5
+	},
+/obj/item/flame/lighter/zippo{
+	pixel_x = 7;
+	pixel_y = -1
+	},
+/turf/simulated/floor/wood,
+/area/warfare/homebase/blue/caproom)
+"nt" = (
+/obj/effect/floor_decal/trench,
+/obj/structure/trench_wall/innercorners{
+	pixel_x = -32;
+	pixel_y = 31
+	},
+/obj/structure/trench_wall{
+	dir = 4;
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/structure/stairs/trenchstairs{
+	dir = 1
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"nv" = (
+/obj/structure/closet/secure_closet/warfare/practicioner,
+/obj/item/clothing/suit/surgeon_apron,
+/obj/item/clothing/suit/surgeon_apron,
+/obj/item/clothing/gloves/latex,
+/obj/item/clothing/gloves/latex,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/item/storage/backpack/satchel/warfare/prac,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"nw" = (
+/obj/machinery/light/small/bunker{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/room)
+"nx" = (
+/obj/effect/floor_decal/trench{
+	dir = 8
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/two)
+"ny" = (
+/obj/machinery/light/caged{
+	pixel_y = 30;
+	pixel_x = 16
+	},
+/obj/structure/trench_wall{
+	dir = 5;
+	pixel_x = -32;
+	layer = 28
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"nz" = (
+/obj/effect/floor_decal/trench{
+	dir = 5
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"nA" = (
+/obj/structure/trench_wall/innercorners{
+	dir = 8
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/space)
+"nD" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/largeroom)
+"nJ" = (
+/obj/structure/trench_wall/innercorners{
+	dir = 8
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/bunker)
+"nK" = (
+/obj/structure/trench_wall/sequel{
+	dir = 8
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"nN" = (
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular,
+/obj/structure/table/rack/shelf/red,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/machinery/light/caged{
+	pixel_y = 30
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"nP" = (
+/obj/effect/landmark/train_marker/exit/blue,
+/obj/structure/train_deco/tracks01,
+/turf/simulated/floor/urban/destroyed,
+/area/warfare/homebase/blue/trainyard)
+"nQ" = (
+/turf/simulated/wall/perspecticrete{
+	integrity = 99999
+	},
+/area/warfare/battlefield/trench_section/underground/indoors)
+"nV" = (
+/obj/structure/announcementspeaker/red{
+	pixel_x = 0;
+	dir = 1
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"oh" = (
+/obj/effect/landmark/start{
+	name = "Red Soldier"
+	},
+/obj/structure/bed/chair/red,
+/obj/machinery/light/small/bunker{
+	dir = 8
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"ol" = (
+/obj/effect/landmark/start/bluecoats,
+/obj/structure/bed/chair/red{
+	dir = 1
+	},
+/turf/simulated/floor/ert/metal01,
+/area/train/blue)
+"om" = (
+/obj/structure/trench_wall{
+	dir = 9;
+	pixel_x = 32;
+	pixel_y = 0;
+	layer = 28
+	},
+/obj/structure/trench_wall/innercorners{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = -32
+	},
+/obj/structure/table/rack/shelf/red,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"oo" = (
+/obj/structure/closet/crate/wooden{
+	pixel_x = -10;
+	pixel_y = 1
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
+"os" = (
+/obj/structure/trench_wall/innercorners{
+	dir = 1
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/red/one)
+"ot" = (
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/room)
+"oy" = (
+/obj/machinery/light/small/bunker{
+	dir = 1
+	},
+/obj/item/device/boombox,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"oz" = (
+/obj/structure/closet/crate{
+	name = "gasmask crate"
+	},
+/obj/item/clothing/mask/gas/red,
+/obj/item/clothing/mask/gas/red,
+/obj/item/clothing/mask/gas/red,
+/obj/item/clothing/mask/gas/red,
+/obj/item/clothing/mask/gas/red,
+/obj/item/clothing/mask/gas/red,
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red)
+"oB" = (
+/obj/structure/announcementspeaker/red{
+	pixel_x = 0;
+	dir = 1
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/trench_section/underground)
+"oD" = (
+/obj/structure/curtain/medical{
+	color = "#b8dddddd"
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/stoneroom)
+"oE" = (
+/obj/machinery/light/caged{
+	dir = 4;
+	pixel_x = -10;
+	pixel_y = 16
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/trench_section/underground)
+"oG" = (
+/obj/item/clothing/accessory/medal/red/brass{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/clothing/accessory/medal/red/brass{
+	pixel_x = 12;
+	pixel_y = 2
+	},
+/obj/item/clothing/accessory/medal/red/pig_iron{
+	pixel_x = 16;
+	pixel_y = 2
+	},
+/obj/item/clothing/accessory/medal/red/gold{
+	pixel_x = 20;
+	pixel_y = 2
+	},
+/obj/structure/table/nosmooth/capnew{
+	pixel_y = -4;
+	dir = 8
+	},
+/obj/item/device/megaphone/red{
+	pixel_x = -1;
+	pixel_y = 7
+	},
+/obj/structure/table/nosmooth/capnew{
+	pixel_y = 28;
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/warfare/homebase/red/caproom)
+"oJ" = (
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/capture_point/blue/two)
+"oK" = (
+/obj/structure/defensive_barrier{
+	dir = 1;
+	pixel_y = 12;
+	secured = 1
+	},
+/obj/hammereditor/nodraw,
+/turf/simulated/wall/perspecticrete{
+	layer = 29;
+	plane = -150
+	},
+/area/warfare/battlefield/trench_section/underground)
+"oN" = (
+/obj/structure/warfare_itemeater/blue,
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/blue/largeroom)
+"oQ" = (
+/obj/effect/landmark/start{
+	name = "Blue Squad Leader"
+	},
+/obj/machinery/light/small/bunker{
+	pixel_x = 16;
+	pixel_y = 32
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"oR" = (
+/obj/structure/trench_wall,
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/red/one)
+"oS" = (
+/obj/effect/decal/cleanable/cobweb2{
+	dir = 1
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/hallway)
+"oT" = (
+/obj/machinery/light/caged{
+	pixel_y = -2;
+	dir = 1;
+	pixel_x = 16
+	},
+/obj/structure/trench_wall{
+	dir = 9;
+	pixel_x = -32;
+	layer = 28
+	},
+/obj/structure/table/rack/holorack,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"oV" = (
+/obj/machinery/light/caged{
+	pixel_y = -1;
+	dir = 1;
+	pixel_x = 0
+	},
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/homebase/red)
+"pb" = (
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/stoneroom)
+"pd" = (
+/obj/item/flame/candle,
+/obj/item/storage/box/matches,
+/obj/structure/table/rack/nosmooth/wood/alt,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"pe" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/blue/trainyard)
+"ph" = (
+/obj/effect/floor_decal/trench{
+	dir = 5
+	},
+/obj/machinery/light/caged{
+	pixel_y = -1;
+	dir = 1;
+	pixel_x = 0
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"pm" = (
+/obj/machinery/light/caged{
+	pixel_y = 30;
+	pixel_x = 0
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"pq" = (
+/obj/structure/announcementspeaker/blue{
+	pixel_y = 0;
+	dir = 8
+	},
+/turf/simulated/open,
+/area/warfare/battlefield/capture_point/blue/two)
+"pr" = (
+/obj/effect/landmark/start{
+	name = "Red Soldier"
+	},
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/room)
+"pt" = (
+/obj/structure/announcementspeaker/red{
+	pixel_x = 0;
+	dir = 4
+	},
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/room)
+"pu" = (
+/obj/sound_emitter/loop/env_canal,
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
+"pv" = (
+/obj/machinery/light/caged{
+	dir = 8;
+	pixel_x = 10;
+	pixel_y = 14
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/trench_section/underground)
+"pw" = (
+/obj/structure/toilet{
+	dir = 4;
+	icon_state = "toilet00"
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/room)
+"px" = (
+/obj/effect/darkout_teleporter/redcoats,
+/turf/unsimulated/wall/submarine/doors,
+/area/train/red)
+"pC" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/hallway)
+"pF" = (
+/turf/simulated/wall/perspecticrete,
+/area/space)
+"pG" = (
+/obj/machinery/light/caged{
+	pixel_y = 30;
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/trench{
+	dir = 1
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"pI" = (
+/obj/machinery/light/small/bunker{
+	dir = 8;
+	pixel_x = 0;
+	pixel_y = 15
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"pL" = (
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/one)
+"pS" = (
+/obj/structure/bed/chair/blue{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 11;
+	buckle_pixel_shift = "x=0;y=11"
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/largeroom)
+"pV" = (
+/turf/simulated/open,
+/area/warfare/homebase/blue/stoneroom)
+"pX" = (
+/obj/structure/bed,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/room)
+"pZ" = (
+/obj/structure/trench_wall/sequel{
+	dir = 4
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"qa" = (
+/obj/effect/floor_decal/stones{
+	dir = 1
+	},
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/battlefield/trench_section)
+"qb" = (
+/obj/effect/floor_decal/trench{
+	dir = 5
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/two)
+"qf" = (
+/obj/machinery/light/caged{
+	dir = 8;
+	pixel_x = 10;
+	pixel_y = 0
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/underground)
+"qg" = (
+/mob/living/simple_animal/hostile/retaliate/rat,
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"qj" = (
+/obj/effect/landmark/start/morale_officer,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"qk" = (
+/obj/structure/trench_wall/innercorners{
+	dir = 4
+	},
+/obj/structure/trench_wall{
+	dir = 4
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/indoors)
+"ql" = (
+/obj/effect/floor_decal/urban/trim1{
+	dir = 1
+	},
+/obj/effect/floor_decal/urban/trim1,
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/room)
+"qm" = (
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/ash,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/hallway)
+"qq" = (
+/obj/item/storage/firstaid/surgery,
+/obj/structure/table/rack/nosmooth/metal,
+/obj/item/reagent_containers/spray/cleaner/warfare{
+	pixel_x = 4;
+	pixel_y = 17
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"qt" = (
+/obj/machinery/light/small/bunker{
+	dir = 1
+	},
+/obj/structure/table/rack/nosmooth/wood,
+/obj/structure/closet/crate/wooden/large/meatball{
+	pixel_x = 0;
+	pixel_y = 11
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = -8;
+	pixel_y = 0
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = 8;
+	pixel_y = 0
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = -8;
+	pixel_y = -5
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = 0;
+	pixel_y = -5
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = 8;
+	pixel_y = -5
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = -8;
+	pixel_y = -10
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = 0;
+	pixel_y = -10
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = 8;
+	pixel_y = -10
+	},
+/turf/simulated/floor/wood,
+/area/warfare/homebase/red/caproom)
+"qu" = (
+/obj/structure/trench_wall{
+	dir = 6
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/red/one)
+"qx" = (
+/obj/machinery/light/caged{
+	dir = 4;
+	pixel_x = -10;
+	pixel_y = 0
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/underground)
+"qD" = (
+/obj/structure/announcementspeaker/red,
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/red/room)
+"qE" = (
+/obj/structure/announcementspeaker/blue{
+	pixel_y = 32
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/trench_section/underground)
+"qF" = (
+/obj/item/melee/classic_baton/factionbanner/red,
+/turf/simulated/floor/tiled,
+/area/warfare/homebase/red/largeroom)
+"qG" = (
+/obj/structure/closet/body_bag,
+/obj/structure/trench_wall/innercorners{
+	dir = 1;
+	pixel_x = 32;
+	pixel_y = 31
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"qH" = (
+/obj/structure/trench_wall/innercorners{
+	dir = 8
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"qI" = (
+/obj/structure/toilet{
+	dir = 8;
+	icon_state = "toilet00"
+	},
+/obj/structure/trench_wall{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/structure/trench_wall/innercorners{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = -32
+	},
+/obj/structure/trench_wall/sequel{
+	dir = 6;
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/room)
+"qL" = (
+/obj/structure/announcementspeaker/red{
+	pixel_x = 0;
+	dir = 1
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/largeroom)
+"qO" = (
+/obj/machinery/light/small/bunker{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"qQ" = (
+/obj/structure/announcementspeaker/red{
+	pixel_y = 32
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/trench_section/underground)
+"qR" = (
+/obj/machinery/light/caged{
+	pixel_y = -14;
+	dir = 1;
+	pixel_x = 0
+	},
+/turf/simulated/open,
+/area/warfare/battlefield/capture_point/blue/two)
+"qT" = (
+/obj/structure/trench_wall/innercorners{
+	dir = 4;
+	pixel_x = -32
+	},
+/obj/structure/trench_wall/innercorners{
+	dir = 8
+	},
+/obj/structure/defensive_barrier{
+	pixel_y = 7;
+	secured = 1;
+	plane = -14
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/space)
+"qW" = (
+/obj/effect/floor_decal/stones{
+	dir = 4
+	},
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/battlefield/trench_section)
+"qY" = (
+/turf/unsimulated/wall/submarine/doors{
+	dir = 1
+	},
+/area/train/red)
+"ra" = (
+/obj/effect/landmark/start{
+	name = "Red Captain"
+	},
+/obj/structure/bed/chair/throne/red{
+	pixel_x = 0;
+	pixel_y = -3;
+	buckle_pixel_shift = "x=0;y=-3"
+	},
+/turf/simulated/floor/wood,
+/area/warfare/homebase/red/caproom)
+"rb" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"rd" = (
+/obj/effect/landmark/start{
+	name = "Red Soldier"
+	},
+/obj/structure/bed/chair/red{
+	dir = 8;
+	pixel_x = -6;
+	pixel_y = 0;
+	buckle_pixel_shift = "x=-6;y=0"
+	},
+/obj/machinery/light/small/bunker{
+	dir = 4
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"re" = (
+/obj/machinery/light/caged{
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/trench{
+	dir = 10
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/one)
+"rf" = (
+/obj/structure/trench_wall/innercorners,
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/blue/two)
+"rg" = (
+/obj/structure/bed/chair/wheelchair,
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/stoneroom)
+"rj" = (
+/obj/effect/landmark/start{
+	name = "Blue Soldier"
+	},
+/obj/structure/bed/chair/blue{
+	dir = 8
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"rk" = (
+/obj/structure/sign/neon/cargo{
+	pixel_y = -32
+	},
+/obj/effect/floor_decal/industrial/direction{
+	dir = 4
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/hallway)
+"rm" = (
+/obj/effect/landmark/start{
+	name = "Red Bartender"
+	},
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/room)
+"rn" = (
+/obj/machinery/light/caged{
+	pixel_y = 30;
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/trench,
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"rp" = (
+/obj/machinery/light/small/bunker{
+	dir = 1
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/hallway)
+"rq" = (
+/obj/structure/warfare_itemeater/blue{
+	pixel_y = 32
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/trench_section/underground)
+"rs" = (
+/obj/structure/announcementspeaker/red{
+	pixel_x = 0;
+	dir = 1
+	},
+/turf/simulated/open,
+/area/warfare/battlefield/capture_point/red/two)
+"rv" = (
+/obj/machinery/light/caged{
+	pixel_y = 25;
+	pixel_x = 0
+	},
+/obj/structure/defensive_barrier{
+	secured = 1;
+	dir = 4;
+	pixel_x = 2;
+	pixel_y = 1
+	},
+/obj/hammereditor/nodraw,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/hallway)
+"rx" = (
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/red/trainyard)
+"ry" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/dust,
+/obj/effect/lighting_dummy/daylight,
+/obj/effect/landmark/train_marker/teleport/red,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/red/trainyard)
+"rA" = (
+/obj/structure/storage/cabinet{
+	dir = 4;
+	pixel_x = 0;
+	pixel_y = 3
+	},
+/obj/item/ammo_magazine/handful/revolver/two{
+	initial_ammo = 6
+	},
+/obj/item/ammo_magazine/handful/revolver/two{
+	initial_ammo = 6
+	},
+/obj/item/ammo_magazine/handful/revolver/two{
+	initial_ammo = 6
+	},
+/obj/structure/announcementspeaker/blue{
+	pixel_y = 32
+	},
+/obj/item/reagent_containers/pill/cyanide{
+	icon_state = "pill4";
+	name = "cyanide pill";
+	desc = "It's marked 'KCN'. Smells vaguely of almonds. Your last resort.."
+	},
+/obj/item/reagent_containers/pill/cyanide{
+	icon_state = "pill4";
+	name = "cyanide pill";
+	desc = "It's marked 'KCN'. Smells vaguely of almonds. Your last resort.."
+	},
+/obj/item/reagent_containers/pill/cyanide{
+	icon_state = "pill4";
+	name = "cyanide pill";
+	desc = "It's marked 'KCN'. Smells vaguely of almonds. Your last resort.."
+	},
+/turf/simulated/floor/wood,
+/area/warfare/homebase/blue/caproom)
+"rB" = (
+/obj/structure/table/rack/shelf/red,
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/red/largeroom)
+"rC" = (
+/obj/machinery/button/remote/blast_door/lever,
+/obj/hammereditor/nodraw,
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/blue/room)
+"rF" = (
+/obj/machinery/light/small/bunker{
+	dir = 4
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/hallway)
+"rI" = (
+/obj/structure/trench_wall,
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"rJ" = (
+/obj/effect/landmark/train_marker/entry/blue,
+/obj/structure/train_deco/tracks01,
+/obj/hammereditor/nodraw/deco/shadowpaint{
+	opacity = 1;
+	dir = 8
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/trainyard)
+"rK" = (
+/obj/structure/toilet{
+	dir = 8;
+	icon_state = "toilet00"
+	},
+/obj/machinery/light/small/bunker{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/room)
+"rM" = (
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/blue/room)
+"rN" = (
+/obj/effect/landmark/start/redcoats,
+/obj/machinery/light/small,
+/obj/structure/bed/chair/gray{
+	dir = 1
+	},
+/turf/simulated/floor/ert/metal01,
+/area/train/red)
+"rT" = (
+/obj/machinery/light/small/bunker{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/hallway)
+"rV" = (
+/obj/effect/floor_decal/urban/trim1,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
+"rZ" = (
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/stoneroom)
+"sg" = (
+/obj/structure/table/rack/nosmooth/metal,
+/obj/machinery/light/small/bunker{
+	dir = 8;
+	pixel_x = 0;
+	pixel_y = 15
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"sk" = (
+/obj/machinery/light/small/bunker{
+	dir = 1
+	},
+/obj/structure/table/rack/nosmooth/wood,
+/obj/structure/closet/crate/wooden/large/meatball{
+	pixel_x = 0;
+	pixel_y = 11
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = -8;
+	pixel_y = 0
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = 8;
+	pixel_y = 0
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = -8;
+	pixel_y = -5
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = 0;
+	pixel_y = -5
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = 8;
+	pixel_y = -5
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = -8;
+	pixel_y = -10
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = 0;
+	pixel_y = -10
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = 8;
+	pixel_y = -10
+	},
+/turf/simulated/floor/wood,
+/area/warfare/homebase/blue/caproom)
+"sm" = (
+/obj/structure/bed/roller,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/stoneroom)
+"sn" = (
+/obj/structure/table/rack/nosmooth/wood/alt,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"sr" = (
+/obj/structure/trench_wall{
+	dir = 6
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/indoors)
+"sw" = (
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/hallway)
+"sx" = (
+/obj/structure/trench_wall/innercorners{
+	dir = 4
+	},
+/obj/structure/trench_wall/innercorners{
+	dir = 8;
+	pixel_x = 32
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/space)
+"sz" = (
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/toxin,
+/obj/structure/table/rack/shelf/red,
+/obj/structure/table/woodentable/shelf{
+	pixel_y = 26;
+	density = 0
+	},
+/obj/item/reagent_containers/rag{
+	pixel_x = -5;
+	pixel_y = 28
+	},
+/obj/item/reagent_containers/glass/bottle/antique/slim/chloroform{
+	pixel_x = 1;
+	pixel_y = 31;
+	icon_state = "slim_rd"
+	},
+/obj/item/reagent_containers/glass/bottle/antique/slim/chloroform{
+	pixel_x = 10;
+	pixel_y = 32;
+	icon_state = "slim_rd"
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"sA" = (
+/obj/structure/trench_wall{
+	dir = 8
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/space)
+"sB" = (
+/obj/structure/trench_wall/innercorners{
+	dir = 8
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground)
+"sE" = (
+/obj/machinery/light/small/bunker{
+	dir = 1
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/hallway)
+"sJ" = (
+/turf/space,
+/area/warfare/homebase/blue/trainyard)
+"sK" = (
+/obj/machinery/light/small/bunker{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/hallway)
+"sL" = (
+/obj/machinery/light/caged{
+	pixel_y = -1;
+	dir = 1;
+	pixel_x = 0
+	},
+/obj/structure/table/rack/shelf/red,
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/room)
+"sN" = (
+/obj/hammereditor/nodraw/deco/shadowpaint,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/trainyard)
+"sU" = (
+/obj/item/paper/crumpled,
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
+"sW" = (
+/obj/structure/trench_wall{
+	dir = 8
+	},
+/obj/hammereditor/nodraw/deco/shadowpaint{
+	dir = 1
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/space)
+"sY" = (
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/ramp{
+	dir = 8;
+	icon_state = "ramptop"
+	},
+/area/warfare/homebase/blue/stoneroom)
+"tb" = (
+/obj/structure/table/woodentable/shelf{
+	pixel_y = 13
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/largeroom)
+"tc" = (
+/obj/effect/floor_decal/trench{
+	dir = 8
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"tg" = (
+/obj/structure/table/woodentable/shelf{
+	pixel_y = 13
+	},
+/obj/item/device/boombox/stationary{
+	pixel_x = 1;
+	pixel_y = 16
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/largeroom)
+"tj" = (
+/obj/machinery/light/caged{
+	pixel_y = -1;
+	dir = 1;
+	pixel_x = 0
+	},
+/turf/simulated/floor/wood,
+/area/warfare/homebase/red)
+"tk" = (
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/hallway)
+"tn" = (
+/obj/hammereditor/nodraw,
+/turf/simulated/floor/ert/metal01,
+/area/train/red)
+"ts" = (
+/obj/machinery/light,
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/room)
+"tu" = (
+/obj/structure/trench_wall/sequel{
+	dir = 8
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"ty" = (
+/obj/effect/landmark/start{
+	name = "Blue Soldier"
+	},
+/obj/machinery/light/small/bunker{
+	dir = 8
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"tA" = (
+/obj/machinery/light/small/bunker{
+	dir = 4;
+	pixel_x = 0;
+	pixel_y = 15
+	},
+/obj/structure/phone/rotary/admin/red,
+/obj/structure/table/rack/nosmooth/metal,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"tI" = (
+/obj/machinery/bodyscanner{
+	dir = 4;
+	icon_state = "body_scanner_0"
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"tN" = (
+/obj/machinery/light/small/bunker{
+	dir = 4
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"tR" = (
+/obj/effect/lighting_dummy/daylight,
+/obj/structure/train_deco/tracks01,
+/obj/effect/landmark/train_marker/idle/blue{
+	pixel_y = 16
+	},
+/obj/effect/landmark/train_marker/teleport/blue,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/trainyard)
+"tT" = (
+/obj/random/canned_food/red,
+/obj/random/canned_food/red,
+/obj/random/canned_food/red,
+/obj/structure/table/rack/shelf/red,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/room)
+"tW" = (
+/obj/structure/trench_wall{
+	dir = 10
+	},
+/obj/hammereditor/nodraw,
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/space)
+"tX" = (
+/obj/machinery/door/airlock/multi_tile/metal/maintenance/blue,
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/stoneroom)
+"ua" = (
+/obj/machinery/door/blast/shutters{
+	dir = 2
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/room)
+"uc" = (
+/obj/structure/cargo_pad/red,
+/obj/structure/window/reinforced{
+	dir = 4;
+	icon_state = "rwindow"
+	},
+/obj/machinery/light/small/bunker{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/room)
+"uf" = (
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 10
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"ug" = (
+/obj/machinery/light/small/bunker{
+	dir = 4
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"ui" = (
+/obj/effect/floor_decal/industrial/warning/dust/corner{
+	dir = 1
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/blue/trainyard)
+"uj" = (
+/obj/effect/floor_decal/trench{
+	dir = 8
+	},
+/obj/machinery/light/caged{
+	pixel_y = -1;
+	dir = 1;
+	pixel_x = 0
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"ul" = (
+/obj/machinery/light/small/bunker{
+	dir = 8;
+	pixel_x = 0;
+	pixel_y = 15
+	},
+/obj/structure/phone/rotary/admin,
+/obj/structure/table/rack/nosmooth/metal,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"um" = (
+/obj/structure/trench_wall/innercorners{
+	dir = 1;
+	pixel_x = 32;
+	pixel_y = 31
+	},
+/obj/structure/trench_wall{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/structure/stairs/trenchstairs{
+	dir = 1
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"ur" = (
+/obj/structure/toilet{
+	dir = 4;
+	icon_state = "toilet00"
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/room)
+"us" = (
+/obj/machinery/light/small/bunker,
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/blue/largeroom)
+"uw" = (
+/obj/structure/closet/secure_closet/medical1/warfare,
+/obj/item/clothing/suit/surgeon_apron,
+/obj/item/clothing/suit/surgeon_apron,
+/obj/item/clothing/suit/surgeon_apron,
+/obj/item/clothing/suit/surgeon_apron,
+/obj/item/storage/backpack/satchel/warfare/prac,
+/obj/item/storage/backpack/satchel/warfare/prac,
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/room)
+"uz" = (
+/obj/structure/trench_wall,
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/blue/two)
+"uA" = (
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/homebase/red/largeroom)
+"uB" = (
+/obj/effect/landmark/start{
+	name = "Blue Soldier"
+	},
+/obj/machinery/light/small/bunker{
+	dir = 4
+	},
+/obj/structure/bed/chair/blue,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"uC" = (
+/obj/item/flame/candle,
+/obj/item/device/compass,
+/obj/item/device/compass,
+/obj/item/device/compass,
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 6
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"uD" = (
+/obj/machinery/light/small/bunker{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/structure/announcementspeaker/blue{
+	pixel_y = 0;
+	dir = 8
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"uH" = (
+/obj/structure/announcementspeaker/red{
+	id = "Bluecoats";
+	dir = 4
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/hallway)
+"uK" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/stoneroom)
+"uL" = (
+/obj/structure/table/nosmooth/capnew{
+	pixel_y = -4
+	},
+/obj/item/device/flashlight/lamp/captain/blue{
+	pixel_x = 15;
+	pixel_y = 9
+	},
+/obj/structure/announcementmicrophone/blue{
+	pixel_x = -14;
+	pixel_y = 12;
+	plane = -60
+	},
+/obj/item/waxstamp/blue{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = 0;
+	pixel_y = 3
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/simulated/floor/wood,
+/area/warfare/homebase/blue/caproom)
+"uN" = (
+/obj/structure/trench_wall{
+	dir = 1
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"uO" = (
+/obj/effect/floor_decal/industrial/warning/dust/corner{
+	dir = 4
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/blue/trainyard)
+"uP" = (
+/obj/structure/dirt_wall,
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/battlefield/trench_section/hallway)
+"uS" = (
+/obj/structure/table/rack,
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/stoneroom)
+"uW" = (
+/obj/effect/floor_decal/trench{
+	dir = 10
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"uX" = (
+/obj/structure/train_deco/tracks01,
+/obj/effect/landmark/train_marker/exit/red,
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/trainyard)
+"va" = (
+/obj/structure/trench_wall{
+	dir = 8
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/bunker)
+"vb" = (
+/obj/hammereditor/nodraw/deco/shadowpaint{
+	opacity = 1;
+	dir = 4
+	},
+/obj/hammereditor/nodraw/deco/shadowpaint{
+	opacity = 1;
+	dir = 1
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/trainyard)
+"vd" = (
+/obj/structure/trench_wall{
+	dir = 4
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"vg" = (
+/obj/item/flame/candle,
+/obj/item/storage/box/matches,
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 6
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"vh" = (
+/obj/machinery/light/small/bunker{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/structure/announcementspeaker/red{
+	pixel_x = 0;
+	dir = 8
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"vk" = (
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"vl" = (
+/obj/effect/floor_decal/urban/trim1,
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/hallway)
+"vn" = (
+/obj/item/flame/lighter/zippo{
+	name = "History";
+	desc = "To destroy the old, from wildlife to simple documents - history can be destroyed with a single motion of the thumb"
+	},
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"vo" = (
+/turf/simulated/wall/perspecticrete{
+	color = "#000000"
+	},
+/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
+"vr" = (
+/obj/effect/structure{
+	anchored = 1;
+	icon = 'icons/obj/power.dmi';
+	icon_state = "smes";
+	layer = 222
+	},
+/obj/effect/floor_decal/industrial/warning/dust/corner{
+	dir = 4
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/hallway)
+"vt" = (
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/largeroom)
+"vu" = (
+/obj/structure/defensive_barrier{
+	dir = 1;
+	pixel_y = 12;
+	secured = 1
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/trench_section/underground)
+"vz" = (
+/obj/structure/announcementspeaker/blue{
+	pixel_y = 0;
+	dir = 4
+	},
+/turf/simulated/open,
+/area/warfare/battlefield/capture_point/blue/two)
+"vA" = (
+/obj/structure/curtain,
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/stoneroom)
+"vC" = (
+/obj/machinery/optable{
+	dir = 8;
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"vE" = (
+/obj/effect/sub_marker/float{
+	id = "SUB_END"
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/homebase/red)
+"vH" = (
+/obj/hammereditor/nodraw/deco/shutter_quarter{
+	dir = 4
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/room)
+"vK" = (
+/obj/effect/landmark/start{
+	name = "Blue Scavenger"
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/room)
+"vM" = (
+/obj/structure/toilet{
+	dir = 4;
+	icon_state = "toilet00"
+	},
+/obj/machinery/light/caged{
+	pixel_y = 30;
+	pixel_x = 0
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/room)
+"vN" = (
+/obj/machinery/light/caged{
+	pixel_y = 25;
+	pixel_x = 0
+	},
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/homebase/blue)
+"vP" = (
+/obj/effect/landmark/start{
+	name = "Blue Soldier"
+	},
+/obj/structure/bed/chair/blue{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 11;
+	buckle_pixel_shift = "x=0;y=11"
+	},
+/obj/machinery/light/small/bunker{
+	dir = 8
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"vQ" = (
+/obj/machinery/light/small/bunker{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/structure/table/rack/nosmooth/wood/alt,
+/obj/structure/bed/chair/red,
+/obj/structure/bed/chair/red{
+	pixel_x = -1;
+	pixel_y = 6
+	},
+/obj/structure/bed/chair/red{
+	pixel_x = 1;
+	pixel_y = 13
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"vR" = (
+/obj/structure/announcementspeaker/blue{
+	pixel_x = 0;
+	dir = 1
+	},
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/battlefield/capture_point/blue/one)
+"vS" = (
+/obj/machinery/door/unpowered/simple/wood/captain{
+	initial_lock_value = "red";
+	locked = 1
+	},
+/obj/hammereditor/nodraw,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"vU" = (
+/obj/machinery/light/caged{
+	pixel_y = 30;
+	pixel_x = 0
+	},
+/turf/simulated/open,
+/area/warfare/battlefield/capture_point/red/two)
+"vW" = (
+/obj/machinery/light/caged{
+	pixel_y = -1;
+	dir = 1;
+	pixel_x = 0
+	},
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/battlefield/trench_section)
+"vX" = (
+/obj/structure/curtain/medical{
+	color = "#b8dddddd"
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/room)
+"vY" = (
+/obj/hammereditor/nodraw/deco/shadowpaint{
+	opacity = 1;
+	dir = 4
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/trainyard)
+"wc" = (
+/obj/effect/floor_decal/trench{
+	dir = 6
+	},
+/obj/structure/banner/blue/small{
+	pixel_y = 32
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"we" = (
+/obj/hammereditor/nodraw/deco/shadowpaint{
+	opacity = 1;
+	dir = 4
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
+"wh" = (
+/obj/structure/train_deco/platform{
+	pixel_y = 3
+	},
+/obj/hammereditor/playerclip,
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/trainyard)
+"wj" = (
+/obj/structure/defensive_barrier{
+	dir = 1;
+	pixel_y = 12;
+	secured = 1
+	},
+/obj/structure/barbwire,
+/obj/hammereditor/nodraw,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/hallway)
+"wl" = (
+/obj/machinery/light/caged{
+	pixel_y = 30;
+	pixel_x = 0
+	},
+/obj/structure/closet/crate,
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/room)
+"wo" = (
+/obj/structure/trench_wall/innercorners{
+	dir = 4
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/indoors)
+"wq" = (
+/obj/effect/floor_decal/trench{
+	dir = 5
+	},
+/obj/machinery/light/caged{
+	pixel_y = -1;
+	dir = 1;
+	pixel_x = 0
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"wu" = (
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/hallway)
+"wv" = (
+/obj/effect/landmark/start{
+	name = "Blue Soldier"
+	},
+/obj/structure/bed/chair/blue{
+	dir = 4
+	},
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"wz" = (
+/obj/machinery/light/small/bunker{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/room)
+"wA" = (
+/obj/structure/table/rack,
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/stoneroom)
+"wC" = (
+/turf/simulated/floor/urban/destroyed,
+/area/warfare/homebase/blue/trainyard)
+"wF" = (
+/obj/structure/trench_wall/sequel{
+	dir = 8
+	},
+/obj/structure/trench_wall{
+	dir = 9
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/indoors)
+"wG" = (
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
+"wJ" = (
+/obj/effect/floor_decal/trench{
+	dir = 4
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"wK" = (
+/obj/structure/trench_wall{
+	dir = 10
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/space)
+"wR" = (
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/hallway)
+"wU" = (
+/obj/structure/train_deco/sides{
+	dir = 1
+	},
+/obj/effect/lighting_dummy/daylight,
+/obj/hammereditor/playerclip,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/trainyard)
+"wV" = (
+/obj/structure/sign/medholo,
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/red/room)
+"wX" = (
+/turf/unsimulated/wall/submarine/doors{
+	dir = 1
+	},
+/area/warfare/homebase/blue/room)
+"wZ" = (
+/obj/structure/window/reinforced,
+/obj/structure/cargo_pad/blue,
+/obj/structure/window/reinforced{
+	dir = 4;
+	icon_state = "rwindow"
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/room)
+"xc" = (
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/hallway)
+"xd" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/hallway)
+"xe" = (
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue)
+"xf" = (
+/obj/machinery/door/airlock/multi_tile/metal/maintenance/red{
+	locked = 1;
+	maxhealth = 500000
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/homebase/red/hallway)
+"xj" = (
+/obj/structure/trench_wall/sequel{
+	dir = 8
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/indoors)
+"xm" = (
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/trainyard)
+"xo" = (
+/obj/machinery/light/small/bunker{
+	dir = 8
+	},
+/obj/structure/soldiercryo/special/blue,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/stoneroom)
+"xp" = (
+/turf/simulated/floor/ert/metal01,
+/area/train/blue)
+"xq" = (
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular,
+/obj/structure/table/rack/shelf/red,
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"xt" = (
+/obj/structure/train_deco/tracks01,
+/obj/hammereditor/nodraw/deco/shadowpaint{
+	opacity = 1;
+	dir = 4
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/trainyard)
+"xw" = (
+/obj/effect/sub_marker/float{
+	id = "MISSION"
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield)
+"xx" = (
+/obj/machinery/light/caged{
+	dir = 8;
+	pixel_x = 10;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/trench{
+	dir = 5
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"xC" = (
+/obj/structure/trench_wall/innercorners,
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground)
+"xI" = (
+/obj/structure/bed/chair/blue{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 11;
+	buckle_pixel_shift = "x=0;y=11"
+	},
+/obj/effect/landmark/start{
+	name = "Blue Soldier"
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/largeroom)
+"xK" = (
+/obj/item/flame/candle,
+/obj/item/ammo_box/shotgun,
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 6
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"xL" = (
+/obj/machinery/door/unpowered/simple/wood/captain{
+	initial_lock_value = "red";
+	locked = 1
+	},
+/obj/structure/defensive_barrier{
+	pixel_y = -4;
+	secured = 1;
+	plane = -14
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/indoors)
+"xM" = (
+/obj/structure/reagent_dispensers/watertank{
+	pixel_x = 3;
+	pixel_y = 0
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/room)
+"xR" = (
+/obj/machinery/light/small/bunker,
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/red/largeroom)
+"xS" = (
+/obj/machinery/door/unpowered/simple/wood/captain{
+	initial_lock_value = "captain";
+	locked = 1
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/caproom)
+"xV" = (
+/obj/structure/trench_wall{
+	dir = 10
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/bunker)
+"xW" = (
+/obj/effect/floor_decal/trench{
+	dir = 4
+	},
+/obj/structure/stairs/trenchstairs{
+	dir = 1
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"xZ" = (
+/obj/structure/toilet{
+	dir = 8;
+	icon_state = "toilet00"
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/room)
+"yf" = (
+/obj/effect/floor_decal/industrial/warning/dust/corner{
+	dir = 8
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/red/trainyard)
+"yg" = (
+/obj/effect/floor_decal/urban/trim1,
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/hallway)
+"yh" = (
+/obj/machinery/optable{
+	pixel_x = 4
+	},
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"yj" = (
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/hallway)
+"yn" = (
+/obj/structure/railing/urban{
+	dir = 4
+	},
+/obj/effect/lighting_dummy/daylight,
+/obj/hammereditor/playerclip,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/blue/trainyard)
+"yo" = (
+/obj/structure/trench_wall{
+	dir = 8
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground)
+"yq" = (
+/obj/effect/darkout_teleporter/bluecoats,
+/obj/effect/floor_decal/train_deco/stripes{
+	dir = 4;
+	pixel_y = 11
+	},
+/obj/effect/floor_decal/industrial/warning/dust,
+/obj/effect/landmark/train_marker/teleport/red,
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/red/trainyard)
+"ys" = (
+/obj/effect/lighting_dummy/daylight,
+/obj/structure/train_deco/tracks01,
+/obj/effect/landmark/train_marker/teleport/blue,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/trainyard)
+"yt" = (
+/obj/hammereditor/nodraw/deco/bars,
+/obj/hammereditor/nodraw/deco/bars{
+	pixel_y = 10
+	},
+/obj/hammereditor/nodraw,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"yv" = (
+/obj/effect/floor_decal/trench{
+	dir = 4
+	},
+/obj/structure/stairs/trenchstairs{
+	dir = 1
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"yx" = (
+/obj/structure/table/rack/shelf/red,
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/room)
+"yA" = (
+/obj/structure/trench_wall{
+	dir = 9;
+	pixel_x = 32;
+	pixel_y = 0;
+	layer = 28
+	},
+/obj/structure/trench_wall/innercorners{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = -32
+	},
+/obj/structure/table/rack/holorack,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"yB" = (
+/obj/item/storage/fancy/cigarettes/luckystars,
+/obj/item/flame/candle,
+/obj/item/flame/lighter/random,
+/obj/item/ammo_box/rifle,
+/obj/structure/table/rack/nosmooth/wood/alt,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"yE" = (
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/room)
+"yF" = (
+/obj/hammereditor/nodraw,
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/red/hallway)
+"yG" = (
+/obj/machinery/light/caged{
+	pixel_x = 33;
+	pixel_y = 0
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/two)
+"yH" = (
+/obj/structure/trench_wall/innercorners,
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/room)
+"yJ" = (
+/obj/machinery/door/blast/shutters,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/room)
+"yK" = (
+/obj/structure/table/rack/holorack,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/largeroom)
+"yP" = (
+/obj/structure/curtain,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/room)
+"yR" = (
+/obj/machinery/light/caged{
+	pixel_y = -14;
+	dir = 1;
+	pixel_x = 0
+	},
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/homebase/red)
+"yS" = (
+/obj/machinery/door/blast/shutters{
+	dir = 8
+	},
+/turf/simulated/wall/perspecticrete,
+/area/space)
+"yT" = (
+/obj/structure/trench_wall{
+	dir = 8
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"yZ" = (
+/obj/structure/table/rack/nosmooth/metal,
+/obj/item/storage/firstaid/surgery,
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"za" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/table/rack/nosmooth/metal,
+/obj/item/clothing/gloves/latex{
+	pixel_x = 0;
+	pixel_y = 2
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"zc" = (
+/turf/unsimulated/wall/hammereditor/dev2,
+/area/warfare/homebase/red)
+"zd" = (
+/obj/structure/railing/urban{
+	dir = 4
+	},
+/obj/hammereditor/playerclip,
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/red/trainyard)
+"ze" = (
+/obj/structure/closet/secure_closet/medical1/warfare,
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/room)
+"zg" = (
+/obj/structure/trench_wall{
+	dir = 4
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/space)
+"zl" = (
+/obj/effect/floor_decal/industrial/direction{
+	dir = 4
+	},
+/obj/structure/sign/neon/cargo{
+	pixel_y = -32
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/hallway)
+"zq" = (
+/obj/structure/trench_wall{
+	dir = 1
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/blue/two)
+"zs" = (
+/obj/machinery/light/caged{
+	pixel_y = -1;
+	dir = 1;
+	pixel_x = 0
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/two)
+"zv" = (
+/obj/effect/landmark/start/bluecoats,
+/obj/machinery/light/small,
+/obj/structure/bed/chair/red{
+	dir = 1
+	},
+/turf/simulated/floor/ert/metal01,
+/area/train/blue)
+"zz" = (
+/obj/structure/trench_wall,
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/room)
+"zA" = (
+/obj/structure/trench_wall/innercorners{
+	dir = 1
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/space)
+"zB" = (
+/obj/machinery/light/small/bunker{
+	dir = 1
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"zD" = (
+/obj/effect/floor_decal/trench{
+	dir = 10
+	},
+/obj/machinery/light/caged{
+	pixel_y = -1;
+	dir = 1;
+	pixel_x = 0
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/two)
+"zG" = (
+/obj/machinery/light/small/bunker{
+	dir = 8
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/hallway)
+"zI" = (
+/obj/structure/table/rack/holorack,
+/obj/structure/closet/crate{
+	pixel_x = 1;
+	pixel_y = 16
+	},
+/obj/structure/closet/crate,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/room)
+"zJ" = (
+/obj/structure/cargo_pad/red/captain,
+/obj/structure/warfare_itemeater/red{
+	pixel_y = 32
+	},
+/turf/simulated/floor/wood,
+/area/warfare/homebase/red/caproom)
+"zK" = (
+/obj/machinery/door/airlock/multi_tile/metal/maintenance/red,
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/hallway)
+"zM" = (
+/obj/structure/defensive_barrier{
+	pixel_y = -4;
+	secured = 1;
+	plane = -14
+	},
+/obj/structure/barbwire,
+/obj/hammereditor/nodraw,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/hallway)
+"zO" = (
+/obj/structure/trench_wall/innercorners,
+/obj/structure/trench_wall{
+	dir = 1
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/room)
+"zQ" = (
+/obj/machinery/door/airlock/bunker/blue,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/largeroom)
+"zR" = (
+/obj/structure/trench_wall/innercorners{
+	dir = 4
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"zT" = (
+/obj/structure/train_deco/tracks01,
+/obj/effect/landmark/train_marker/entry/red,
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/trainyard)
+"zU" = (
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/underground)
+"zV" = (
+/obj/structure/closet/crate/wooden{
+	pixel_x = -3;
+	pixel_y = 1
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/blue/trainyard)
+"zW" = (
+/obj/structure/announcementspeaker/blue{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/floor/wood,
+/area/warfare/homebase/blue)
+"Aa" = (
+/obj/machinery/light/caged{
+	dir = 4;
+	pixel_x = -2;
+	pixel_y = 0
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/room)
+"Ac" = (
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/battlefield/capture_point/red/one)
+"Ad" = (
+/obj/machinery/light/small/bunker{
+	dir = 4
+	},
+/obj/structure/table/rack/holorack,
+/obj/item/device/cassette/greed3,
+/obj/item/device/cassette/greed2,
+/obj/item/device/cassette/greed1,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/largeroom)
+"Ag" = (
+/obj/effect/landmark/start{
+	name = "Red Practitioner"
+	},
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/room)
+"Ai" = (
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/blue/hallway)
+"Aj" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
+	},
+/obj/effect/floor_decal/train_deco/stripes{
+	dir = 4
+	},
+/obj/structure/train_deco/platform{
+	pixel_y = 16;
+	dir = 4
+	},
+/obj/effect/lighting_dummy/daylight,
+/obj/effect/darkout_teleporter/bluecoats,
+/obj/effect/landmark/train_marker/teleport/blue,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/blue/trainyard)
+"Ak" = (
+/obj/effect/lighting_dummy/daylight,
+/obj/machinery/camera{
+	dir = 8;
+	pixel_x = -2;
+	pixel_y = 0
+	},
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/blue/trainyard)
+"Al" = (
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/hallway)
+"Ao" = (
+/obj/structure/announcementspeaker/red{
+	pixel_y = 32
+	},
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/room)
+"As" = (
+/obj/machinery/light/caged{
+	pixel_y = -2;
+	dir = 1;
+	pixel_x = 16
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"AA" = (
+/obj/structure/curtain,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/room)
+"AB" = (
+/turf/simulated/floor/exoplanet/water/shallow/lightless/urban,
+/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
+"AH" = (
+/obj/item/folder/envelope{
+	name = "Dictates";
+	desc = "To pass thy dictates to thy chosen envoys. Or to dispatch reward."
+	},
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"AK" = (
+/obj/structure/trench_wall/innercorners{
+	dir = 4
+	},
+/obj/structure/trench_wall/innercorners{
+	dir = 8;
+	pixel_x = 32
+	},
+/obj/structure/defensive_barrier{
+	pixel_y = 7;
+	secured = 1;
+	plane = -14
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/space)
+"AL" = (
+/obj/item/disk/nuclear{
+	name = "Powerlessness";
+	desc = "A trump card wielded by a powerless autarch - an ace in the hole the gods forbade him to play. How tragic"
+	},
+/obj/machinery/light/small/bunker{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 6
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"AM" = (
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/wood,
+/area/warfare/homebase/red/caproom)
+"AO" = (
+/obj/structure/closet/crate/wooden/hardhats,
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
+"AP" = (
+/obj/structure/dirt_wall,
+/obj/structure/announcementspeaker/red{
+	pixel_x = 0;
+	dir = 8
+	},
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/battlefield/trench_section)
+"AR" = (
+/obj/structure/trench_wall/sequel{
+	dir = 8
+	},
+/obj/structure/trench_wall/innercorners{
+	dir = 4;
+	pixel_x = -32
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/space)
+"AT" = (
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
+"AU" = (
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 5
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"AV" = (
+/obj/machinery/light/caged{
+	pixel_y = -14;
+	dir = 1;
+	pixel_x = -16
+	},
+/obj/structure/defensive_barrier{
+	secured = 1;
+	dir = 4;
+	pixel_x = 2;
+	pixel_y = 1
+	},
+/obj/hammereditor/nodraw,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/hallway)
+"AW" = (
+/obj/structure/trench_wall{
+	dir = 6
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground)
+"AX" = (
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/homebase/blue/room)
+"Bb" = (
+/obj/structure/soldiercryo/special/red,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/room)
+"Bc" = (
+/obj/structure/closet/crate,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"Be" = (
+/obj/effect/landmark/start{
+	name = "Blue Engineer"
+	},
+/obj/structure/announcementspeaker/blue{
+	pixel_x = 0;
+	dir = 1
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"Bi" = (
+/obj/structure/closet/crate,
+/obj/random/canned_food/red,
+/obj/random/canned_food/red,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"Bo" = (
+/obj/structure/trench_wall/innercorners{
+	dir = 4
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground)
+"Bq" = (
+/obj/effect/landmark/start{
+	name = "Blue Soldier"
+	},
+/obj/machinery/light/caged{
+	pixel_y = -14;
+	dir = 1;
+	pixel_x = -16
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"Br" = (
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/red/largeroom)
+"Bs" = (
+/obj/structure/vehicle/train/long_passenger{
+	pixel_y = 16;
+	id = "Bluecoats";
+	carriage_amount = 2
+	},
+/turf/space,
+/area/space)
+"Bu" = (
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/room)
+"By" = (
+/obj/structure/storage/cabinet{
+	dir = 4;
+	pixel_x = 0;
+	pixel_y = 3
+	},
+/obj/item/ammo_magazine/handful/revolver/two{
+	initial_ammo = 6
+	},
+/obj/item/ammo_magazine/handful/revolver/two{
+	initial_ammo = 6
+	},
+/obj/item/ammo_magazine/handful/revolver/two{
+	initial_ammo = 6
+	},
+/obj/structure/announcementspeaker/red{
+	pixel_y = 32
+	},
+/obj/item/reagent_containers/pill/cyanide{
+	icon_state = "pill4";
+	name = "cyanide pill";
+	desc = "It's marked 'KCN'. Smells vaguely of almonds. Your last resort.."
+	},
+/obj/item/reagent_containers/pill/cyanide{
+	icon_state = "pill4";
+	name = "cyanide pill";
+	desc = "It's marked 'KCN'. Smells vaguely of almonds. Your last resort.."
+	},
+/obj/item/reagent_containers/pill/cyanide{
+	icon_state = "pill4";
+	name = "cyanide pill";
+	desc = "It's marked 'KCN'. Smells vaguely of almonds. Your last resort.."
+	},
+/obj/item/crowbar/red,
+/turf/simulated/floor/wood,
+/area/warfare/homebase/red/caproom)
+"Bz" = (
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 32
+	},
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"BC" = (
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/homebase/red/hallway)
+"BD" = (
+/obj/structure/trench_wall{
+	dir = 6
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"BE" = (
+/obj/item/gun/projectile/warfare/shig,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
+"BH" = (
+/obj/effect/floor_decal/trench{
+	dir = 6
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"BI" = (
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/blue/trainyard)
+"BK" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
+	},
+/obj/effect/darkout_teleporter/bluecoats,
+/obj/structure/train_deco/platform{
+	pixel_y = 16;
+	dir = 1
+	},
+/obj/effect/lighting_dummy/daylight,
+/obj/effect/landmark/train_marker/teleport/blue,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/blue/trainyard)
+"BM" = (
+/obj/structure/table/nosmooth/capnew{
+	pixel_y = -4
+	},
+/obj/structure/announcementmicrophone/red{
+	pixel_x = -14;
+	pixel_y = 12;
+	plane = -60
+	},
+/obj/item/device/flashlight/lamp/captain{
+	pixel_x = 15;
+	pixel_y = 9
+	},
+/obj/item/waxstamp{
+	pixel_x = 7;
+	pixel_y = 9
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/turf/simulated/floor/wood,
+/area/warfare/homebase/red/caproom)
+"BO" = (
+/obj/structure/closet/crate/wooden/large{
+	icon_closed = "meatball";
+	icon_state = "meatball";
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/red/trainyard)
+"BR" = (
+/obj/machinery/light/small/bunker{
+	dir = 8
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/hallway)
+"BT" = (
+/obj/structure/reagent_dispensers/watertank{
+	pixel_x = 1;
+	pixel_y = 3
+	},
+/obj/effect/decal/cleanable/cobweb2{
+	dir = 1
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/room)
+"BU" = (
+/turf/unsimulated/wall/submarine/doors{
+	dir = 4
+	},
+/area/train/blue)
+"Cb" = (
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/homebase/red)
+"Cc" = (
+/obj/machinery/light/caged{
+	dir = 8;
+	pixel_x = 1;
+	pixel_y = 0
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/room)
+"Cd" = (
+/obj/effect/floor_decal/trench,
+/obj/structure/trench_wall/innercorners{
+	pixel_x = -32;
+	pixel_y = 31
+	},
+/obj/structure/trench_wall{
+	dir = 4;
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/structure/stairs/trenchstairs{
+	dir = 1
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"Ce" = (
+/obj/machinery/light/small/bunker{
+	dir = 8
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"Cg" = (
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/battlefield/capture_point/red/two)
+"Ch" = (
+/obj/effect/landmark/start{
+	name = "Red Soldier"
+	},
+/obj/machinery/light/small/bunker{
+	dir = 8
+	},
+/obj/structure/bed/chair/red,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"Cj" = (
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/blue/largeroom)
+"Cm" = (
+/obj/structure/trench_wall/innercorners{
+	dir = 1;
+	pixel_x = 32;
+	pixel_y = 31
+	},
+/obj/structure/table/rack/nosmooth/metal,
+/obj/item/storage/box/bodybags{
+	pixel_x = 0;
+	pixel_y = -1
+	},
+/obj/item/storage/box/bodybags{
+	pixel_x = 0;
+	pixel_y = 11
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"Cq" = (
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/room)
+"Cr" = (
+/obj/machinery/door/airlock/multi_tile/metal/maintenance/red,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/room)
+"Cs" = (
+/obj/machinery/door/airlock/multi_tile/metal/maintenance{
+	dir = 1;
+	icon_state = "door_closed";
+	name = "Emergency Medical"
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/hallway)
+"Cu" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/blue/trainyard)
+"Cy" = (
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section)
+"CA" = (
+/obj/machinery/body_scanconsole{
+	dir = 4;
+	icon_state = "body_scannerconsole"
+	},
+/obj/machinery/light{
+	pixel_x = 16
+	},
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/room)
+"CB" = (
+/obj/structure/table/rack/nosmooth/metal,
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/room)
+"CC" = (
+/obj/structure/closet/crate/trashcart,
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/hallway)
+"CG" = (
+/obj/machinery/light/caged{
+	pixel_x = -34;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/trench{
+	dir = 10
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/two)
+"CI" = (
+/obj/effect/floor_decal/trench{
+	dir = 5
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/one)
+"CO" = (
+/obj/machinery/light/small/bunker{
+	dir = 8
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/largeroom)
+"CQ" = (
+/obj/structure/bed/chair/red{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 11;
+	buckle_pixel_shift = "x=0;y=11"
+	},
+/turf/simulated/floor/wood,
+/area/warfare/homebase/red/caproom)
+"CR" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	icon_state = "rwindow"
+	},
+/obj/structure/cargo_pad/blue,
+/obj/machinery/light/small/bunker{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/room)
+"CT" = (
+/obj/effect/floor_decal/trench,
+/obj/machinery/light/caged{
+	pixel_y = -1;
+	dir = 1;
+	pixel_x = 0
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/one)
+"CW" = (
+/obj/structure/railing/urban{
+	dir = 4
+	},
+/obj/hammereditor/playerclip,
+/obj/effect/floor_decal/industrial/warning/dust/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning/dust/corner,
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/red/trainyard)
+"CX" = (
+/obj/structure/closet/crate{
+	pixel_x = 1;
+	pixel_y = 16
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/room)
+"CY" = (
+/obj/structure/closet/secure_closet/warfare/newver,
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/trench_section/underground)
+"Da" = (
+/obj/structure/trench_wall/innercorners,
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/indoors)
+"Dc" = (
+/obj/structure/trench_wall/innercorners,
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/space)
+"Dd" = (
+/obj/structure/dirt_wall,
+/obj/machinery/light/caged{
+	dir = 8;
+	pixel_x = 1;
+	pixel_y = 0
+	},
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/battlefield/trench_section)
+"Df" = (
+/obj/machinery/door/airlock/bunker/blue,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/room)
+"Dq" = (
+/obj/machinery/kaos/cargo_machine/red,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/largeroom)
+"Ds" = (
+/obj/structure/closet/crate/medical,
+/obj/item/wirecutters,
+/obj/item/wirecutters,
+/obj/item/storage/firstaid/regular,
+/obj/machinery/light/small/bunker{
+	dir = 1
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"Dw" = (
+/obj/hammereditor/nodraw/deco/shadowpaint{
+	opacity = 1;
+	dir = 4
+	},
+/obj/structure/train_deco/tracks01,
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/trainyard)
+"Dy" = (
+/obj/structure/train_deco/platform{
+	pixel_y = -32;
+	dir = 4;
+	icon_state = "door_closed";
+	icon = 'icons/obj/doors/Doordoublesecglass1x2BLUE.dmi'
+	},
+/obj/structure/reagent_dispensers/watertank/blue,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/room)
+"Dz" = (
+/obj/structure/announcementspeaker/blue{
+	pixel_x = 0;
+	dir = 1
+	},
+/turf/simulated/open,
+/area/warfare/battlefield/capture_point/blue/two)
+"DB" = (
+/obj/structure/trench_wall/sequel{
+	dir = 8
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground)
+"DD" = (
+/turf/simulated/floor/wood,
+/area/warfare/homebase/red)
+"DJ" = (
+/obj/effect/landmark/start{
+	name = "Red Soldier"
+	},
+/obj/structure/bed/chair/red{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 11;
+	buckle_pixel_shift = "x=0;y=11"
+	},
+/obj/machinery/light/small/bunker{
+	dir = 4
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"DK" = (
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"DR" = (
+/obj/effect/floor_decal/trench{
+	dir = 1
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/one)
+"DT" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/dust/corner{
+	dir = 4
+	},
+/obj/effect/lighting_dummy/daylight,
+/obj/effect/landmark/train_marker/teleport/blue,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/blue/trainyard)
+"DW" = (
+/obj/structure/dirt_wall,
+/turf/simulated/floor/dirty/fake,
+/area/warfare/battlefield/capture_point/red/one)
+"DX" = (
+/obj/effect/landmark/start{
+	name = "Blue Practitioner"
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/stoneroom)
+"Ec" = (
+/obj/effect/floor_decal/trench,
+/obj/machinery/light/caged{
+	pixel_y = -1;
+	dir = 1;
+	pixel_x = 0
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/two)
+"Ed" = (
+/obj/hammereditor/nodraw/deco/shutter_quarter,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/room)
+"Ei" = (
+/obj/effect/landmark/start{
+	name = "Blue Soldier"
+	},
+/obj/machinery/light/caged{
+	dir = 4;
+	pixel_x = -19;
+	pixel_y = 0
+	},
+/obj/structure/bed/chair/blue,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"Ek" = (
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/toxin,
+/obj/structure/table/rack/shelf/red,
+/obj/structure/table/woodentable/shelf{
+	pixel_y = 26;
+	density = 0
+	},
+/obj/item/reagent_containers/glass/bottle/antique/slim/chloroform{
+	pixel_x = 10;
+	pixel_y = 32;
+	icon_state = "slim_bl"
+	},
+/obj/item/reagent_containers/rag{
+	pixel_x = -5;
+	pixel_y = 28
+	},
+/obj/item/reagent_containers/glass/bottle/antique/slim/chloroform{
+	pixel_x = 1;
+	pixel_y = 31;
+	icon_state = "slim_bl"
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"El" = (
+/obj/item/flame/candle,
+/obj/item/device/compass,
+/obj/item/device/compass,
+/obj/item/device/compass,
+/obj/item/device/compass,
+/obj/item/device/compass,
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 6
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"Em" = (
+/obj/structure/train_deco/platform{
+	pixel_y = 3;
+	dir = 4
+	},
+/obj/hammereditor/playerclip,
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/trainyard)
+"En" = (
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/blue/trainyard)
+"Eo" = (
+/obj/structure/cargo_pad/blue,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/largeroom)
+"Eu" = (
+/obj/effect/landmark/start{
+	name = "Blue Soldier"
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/room)
+"EC" = (
+/obj/effect/darkout_teleporter{
+	id = "SUB_END";
+	entrance = 0;
+	twoway = 1
+	},
+/obj/hammereditor/nodraw/deco/shadowpaint{
+	dir = 1
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/space)
+"EI" = (
+/obj/structure/dirt_wall,
+/obj/machinery/light/caged{
+	dir = 4;
+	pixel_x = -17;
+	pixel_y = 0
+	},
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/battlefield/trench_section)
+"EM" = (
+/obj/structure/window/reinforced,
+/obj/structure/cargo_pad/red,
+/obj/structure/window/reinforced{
+	dir = 4;
+	icon_state = "rwindow"
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/room)
+"EU" = (
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/room)
+"EV" = (
+/obj/machinery/light/small/bunker{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/floor/wood,
+/area/warfare/homebase/blue/caproom)
+"EW" = (
+/turf/simulated/floor/dirty/indestructable,
+/area/train/red)
+"Fb" = (
+/obj/machinery/computer/operating{
+	icon_state = "console"
+	},
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/room)
+"Fc" = (
+/turf/simulated/floor/dirty/indestructable,
+/area/train/blue)
+"Ff" = (
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/blue/trainyard)
+"Fg" = (
+/obj/machinery/sleeper,
+/obj/structure/trench_wall/innercorners{
+	dir = 4;
+	pixel_x = -32;
+	pixel_y = -32
+	},
+/obj/machinery/light/caged{
+	dir = 1;
+	pixel_y = -1
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"Fi" = (
+/obj/hammereditor/nodraw/deco/shadowpaint{
+	opacity = 1;
+	dir = 8
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/trainyard)
+"Fj" = (
+/turf/simulated/wall/perspectisub,
+/area/train/blue)
+"Fk" = (
+/obj/structure/trench_wall{
+	dir = 4
+	},
+/obj/hammereditor/nodraw/deco/shadowpaint{
+	dir = 1
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/space)
+"Fp" = (
+/obj/structure/trench_wall{
+	dir = 1;
+	pixel_y = -32
+	},
+/obj/item/autopsy_scanner{
+	pixel_x = -4;
+	pixel_y = -1
+	},
+/obj/structure/table/rack/nosmooth/metal,
+/obj/item/reagent_containers/spray/cleaner/warfare/red{
+	pixel_x = 6;
+	pixel_y = 1
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"Fq" = (
+/obj/structure/trench_wall{
+	dir = 4
+	},
+/obj/structure/trench_wall/sequel{
+	dir = 4
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/indoors)
+"Fr" = (
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/red/room)
+"Ft" = (
+/obj/effect/landmark/start/bluecoats,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 37
+	},
+/obj/structure/bed/chair/red,
+/turf/simulated/floor/ert/metal01,
+/area/train/blue)
+"Fw" = (
+/obj/structure/toilet{
+	dir = 4;
+	icon_state = "toilet00"
+	},
+/obj/machinery/light/caged{
+	pixel_y = 30;
+	pixel_x = 0
+	},
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/room)
+"Fx" = (
+/obj/structure/trench_wall/sequel{
+	dir = 8
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/space)
+"Fy" = (
+/obj/structure/trench_wall/innercorners,
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/bunker)
+"FC" = (
+/obj/structure/trench_wall{
+	dir = 1
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/indoors)
+"FE" = (
+/obj/effect/floor_decal/trench{
+	dir = 6
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/two)
+"FL" = (
+/obj/structure/closet/secure_closet/warfare/newver,
+/obj/item/crowbar/red,
+/obj/item/crowbar/red,
+/obj/item/crowbar/red,
+/obj/structure/banner/red/small{
+	pixel_y = 32
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/largeroom)
+"FP" = (
+/obj/machinery/door/airlock/bunker/red,
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/room)
+"FQ" = (
+/obj/effect/landmark/start/bluecoats,
+/obj/structure/bed/chair/red,
+/turf/simulated/floor/ert/metal01,
+/area/train/blue)
+"FR" = (
+/obj/effect/floor_decal/stones,
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/battlefield/trench_section)
+"FS" = (
+/obj/machinery/door/unpowered/simple/wood/captain{
+	desc = "There are constant rumours throughout the front that something is happening beneath it. They believe that the battle above is merely just a cover for something much more severe.";
+	name = "Mysterious Door"
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
+"FT" = (
+/obj/machinery/door/airlock/multi_tile/metal/maintenance/red,
+/obj/effect/decal/cleanable/ash,
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/hallway)
+"FW" = (
+/obj/machinery/door/airlock/multi_tile/metal/maintenance/blue,
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/hallway)
+"FX" = (
+/obj/structure/table/rack/holorack,
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/blue/largeroom)
+"FY" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
+"FZ" = (
+/obj/structure/trench_wall/innercorners{
+	dir = 4;
+	pixel_x = -32
+	},
+/obj/structure/trench_wall/innercorners{
+	dir = 8
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/space)
+"Gd" = (
+/obj/structure/closet/crate/wooden{
+	pixel_x = 4;
+	pixel_y = 12
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/red/trainyard)
+"Gf" = (
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/battlefield/capture_point/red/two)
+"Gg" = (
+/obj/structure/curtain/medical{
+	color = "#b8dddddd"
+	},
+/obj/structure/table/rack/nosmooth/metal,
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/stoneroom)
+"Gh" = (
+/obj/structure/warfare_itemeater/blue{
+	pixel_y = 32
+	},
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/homebase/blue)
+"Gn" = (
+/obj/structure/bed/roller,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/stoneroom)
+"Go" = (
+/obj/structure/table/rack/nosmooth/wood,
+/obj/item/device/compass,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/room)
+"Gs" = (
+/obj/structure/soldiercryo/special/red,
+/obj/machinery/light/small/bunker{
+	dir = 4
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/room)
+"Gu" = (
+/turf/simulated/floor/concrete/random,
+/area/space)
+"Gv" = (
+/obj/structure/train_deco/tracks01,
+/turf/space,
+/area/warfare/homebase/blue/trainyard)
+"GA" = (
+/obj/item/device/compass,
+/obj/item/device/compass,
+/obj/item/device/compass,
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 6
+	},
+/obj/item/flame/candle/blue,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"GD" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	icon_state = "rwindow"
+	},
+/obj/structure/window/reinforced,
+/obj/structure/cargo_pad/blue,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/room)
+"GH" = (
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 10
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"GO" = (
+/obj/machinery/light/small/bunker{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"GR" = (
+/obj/effect/decal/cleanable/cobweb,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/hallway)
+"GT" = (
+/obj/structure/sign/warning/lethal_turrets,
+/obj/hammereditor/nodraw,
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/red/hallway)
+"GX" = (
+/obj/structure/trench_wall/innercorners{
+	dir = 4
+	},
+/obj/structure/trench_wall{
+	dir = 8
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/indoors)
+"Ha" = (
+/obj/structure/railing/urban{
+	dir = 4
+	},
+/obj/effect/lighting_dummy/daylight,
+/obj/hammereditor/playerclip,
+/obj/effect/floor_decal/industrial/warning/dust/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/dust/corner{
+	dir = 4
+	},
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/blue/trainyard)
+"Hc" = (
+/obj/structure/announcementspeaker/blue{
+	pixel_y = 0;
+	dir = 4
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"He" = (
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/light/small/bunker{
+	dir = 8
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"Hf" = (
+/obj/item/flame/candle,
+/obj/item/storage/fancy/cigarettes/carcinomas,
+/obj/item/ammo_box/rifle,
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 5
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"Hj" = (
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/room)
+"Hm" = (
+/obj/effect/landmark/start{
+	name = "Blue Soldier"
+	},
+/obj/machinery/light/caged{
+	dir = 4;
+	pixel_x = -19;
+	pixel_y = 0
+	},
+/obj/structure/bed/chair/blue{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 11;
+	buckle_pixel_shift = "x=0;y=11"
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"Ho" = (
+/mob/living/simple_animal/hostile/retaliate/rat,
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/two)
+"Hq" = (
+/obj/structure/trench_wall/innercorners{
+	dir = 1
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground)
+"Hw" = (
+/obj/structure/train_deco/sides,
+/obj/hammereditor/playerclip,
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/trainyard)
+"Hy" = (
+/turf/simulated/floor/urban/cinder,
+/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
+"HE" = (
+/obj/structure/reagent_dispensers/watertank/blue,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/room)
+"HH" = (
+/obj/structure/stairs/trenchstairs{
+	dir = 1
+	},
+/obj/structure/announcementspeaker/red{
+	pixel_y = 32
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/one)
+"HL" = (
+/obj/machinery/body_scanconsole{
+	dir = 4;
+	icon_state = "body_scannerconsole"
+	},
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"HN" = (
+/obj/structure/closet/crate,
+/obj/random/canned_food/blue,
+/obj/random/canned_food/blue,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"HO" = (
+/obj/structure/trench_wall{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/structure/table/rack/shelf/red,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/room)
+"HQ" = (
+/obj/effect/floor_decal/trench{
+	dir = 1
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"HS" = (
+/obj/structure/closet/crate/wooden{
+	pixel_x = 4;
+	pixel_y = -8
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/blue/trainyard)
+"HT" = (
+/obj/item/storage/fancy/cigarettes/jerichos,
+/obj/item/flame/candle,
+/obj/item/flame/lighter/random,
+/obj/structure/table/rack/nosmooth/wood/alt,
+/obj/structure/announcementspeaker/red{
+	pixel_x = 0;
+	dir = 4
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"HU" = (
+/obj/machinery/light/caged{
+	pixel_y = -1;
+	dir = 1;
+	pixel_x = 16
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"Ic" = (
+/obj/machinery/light,
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"Id" = (
+/obj/machinery/light/caged{
+	dir = 8;
+	pixel_x = 10;
+	pixel_y = 13
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/trench_section/underground)
+"Ie" = (
+/obj/hammereditor/nodraw/deco/shadowpaint{
+	dir = 1
+	},
+/turf/simulated/floor/concrete/random,
+/area/space)
+"If" = (
+/obj/machinery/kaos/cargo_machine/blue,
+/turf/simulated/floor/wood,
+/area/warfare/homebase/blue/caproom)
+"Ig" = (
+/obj/effect/floor_decal/trench{
+	dir = 4
+	},
+/obj/machinery/light/caged{
+	pixel_y = -1;
+	dir = 1;
+	pixel_x = 0
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/two)
+"Ih" = (
+/obj/machinery/kaos/cargo_machine/blue,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/largeroom)
+"Ik" = (
+/obj/structure/trench_wall{
+	dir = 6
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/bunker)
+"Ip" = (
+/obj/structure/toilet{
+	dir = 8;
+	icon_state = "toilet00"
+	},
+/obj/machinery/light/caged{
+	pixel_y = 30;
+	pixel_x = 0
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/room)
+"It" = (
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/room)
+"Iw" = (
+/obj/structure/closet/crate/wooden/large{
+	icon_closed = "meatball";
+	icon_state = "meatball";
+	pixel_x = 0;
+	pixel_y = -15
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/blue/trainyard)
+"Iy" = (
+/obj/structure/trench_wall/innercorners{
+	dir = 4
+	},
+/obj/structure/trench_wall/innercorners{
+	dir = 8;
+	pixel_x = 32
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/space)
+"Iz" = (
+/obj/structure/warfare_itemeater/red,
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/red/largeroom)
+"IF" = (
+/obj/structure/poster/red,
+/obj/hammereditor/nodraw,
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/red/hallway)
+"IK" = (
+/obj/hammereditor/nodraw/deco/bars,
+/turf/simulated/floor/dirty/indestructable,
+/area/space)
+"IN" = (
+/obj/effect/landmark/start{
+	name = "Red Soldier"
+	},
+/obj/structure/bed/chair/red{
+	dir = 4;
+	pixel_x = 6;
+	pixel_y = 0;
+	buckle_pixel_shift = "x=6;y=0"
+	},
+/obj/machinery/light/small/bunker{
+	dir = 8
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"IP" = (
+/obj/effect/floor_decal/train_deco/stripes{
+	dir = 4;
+	pixel_y = 11
+	},
+/obj/effect/darkout_teleporter/bluecoats,
+/obj/effect/floor_decal/industrial/warning/dust,
+/obj/effect/landmark/train_marker/teleport/red,
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/red/trainyard)
+"IQ" = (
+/obj/structure/trench_wall{
+	dir = 10
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/indoors)
+"IR" = (
+/obj/structure/dirt_wall,
+/obj/structure/announcementspeaker/red{
+	pixel_x = 0;
+	dir = 4
+	},
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/battlefield/trench_section)
+"IV" = (
+/obj/structure/sign/medholo,
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/blue/stoneroom)
+"IW" = (
+/obj/machinery/light/small/bunker{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/room)
+"IX" = (
+/obj/effect/landmark/start{
+	name = "Red Soldier"
+	},
+/obj/structure/bed/chair/red,
+/obj/machinery/light/small/bunker{
+	dir = 4
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"IZ" = (
+/obj/effect/floor_decal/trench{
+	dir = 9
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"Jb" = (
+/obj/hammereditor/nodraw/deco/shadowpaint{
+	opacity = 1;
+	dir = 8
+	},
+/obj/structure/train_deco/tracks01,
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/trainyard)
+"Jc" = (
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"Jd" = (
+/obj/effect/landmark/start{
+	name = "Red Scavenger"
+	},
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/room)
+"Je" = (
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/room)
+"Jj" = (
+/turf/space,
+/area/space)
+"Jm" = (
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/hallway)
+"Jv" = (
+/obj/structure/announcementspeaker/red{
+	id = "Bluecoats"
+	},
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/blue/room)
+"Jy" = (
+/obj/effect/landmark/start{
+	name = "Blue Soldier"
+	},
+/obj/machinery/light/caged{
+	pixel_y = 30;
+	pixel_x = -16
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"JG" = (
+/obj/structure/trench_wall{
+	dir = 10
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/blue/two)
+"JH" = (
+/obj/machinery/light/caged{
+	pixel_x = 34;
+	pixel_y = 0
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/one)
+"JK" = (
+/obj/structure/sign/neon/armory{
+	pixel_y = 32;
+	color = "FFFF00"
+	},
+/obj/effect/floor_decal/industrial/direction{
+	dir = 4
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/hallway)
+"JL" = (
+/obj/effect/landmark/start{
+	name = "Red Soldier"
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"JR" = (
+/obj/effect/decal/cleanable/cobweb2{
+	dir = 8
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/hallway)
+"JT" = (
+/obj/structure/announcementspeaker/blue{
+	pixel_x = 0;
+	dir = 1
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/trench_section/underground)
+"JU" = (
+/obj/structure/trench_wall{
+	dir = 1
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/room)
+"JX" = (
+/obj/effect/landmark/start{
+	name = "Red Soldier"
+	},
+/obj/structure/announcementspeaker/red{
+	pixel_y = 32
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"Kg" = (
+/obj/effect/floor_decal/trench{
+	dir = 8
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/one)
+"Kh" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	icon_state = "rwindow"
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/room)
+"Kk" = (
+/obj/machinery/light{
+	pixel_x = 16
+	},
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/room)
+"Km" = (
+/obj/hammereditor/nodraw,
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/red/largeroom)
+"Ku" = (
+/obj/structure/trench_wall{
+	dir = 4
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/red/one)
+"Kv" = (
+/obj/structure/closet/secure_closet/warfare/practicioner,
+/obj/item/clothing/suit/surgeon_apron,
+/obj/item/clothing/suit/surgeon_apron,
+/obj/item/clothing/gloves/latex,
+/obj/item/clothing/gloves/latex,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/item/storage/backpack/satchel/warfare/prac/blue,
+/obj/structure/announcementspeaker/blue{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"Kx" = (
+/obj/machinery/light/small/bunker{
+	dir = 8;
+	pixel_x = 0;
+	pixel_y = 15
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/largeroom)
+"Ky" = (
+/obj/effect/landmark/start,
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/homebase/red)
+"KB" = (
+/obj/effect/landmark{
+	name = "tdome1"
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/homebase/red)
+"KH" = (
+/obj/structure/trench_wall/innercorners{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = -32
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"KI" = (
+/obj/effect/floor_decal/stones,
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/battlefield/capture_point/blue/one)
+"KO" = (
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/blue/caproom)
+"KU" = (
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red)
+"KV" = (
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/largeroom)
+"KY" = (
+/obj/item/device/flashlight/lantern{
+	on = 1;
+	pixel_x = -6;
+	pixel_y = -10
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/trench_section/underground)
+"Lc" = (
+/obj/effect/floor_decal/stones,
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/battlefield/capture_point/blue/two)
+"Li" = (
+/obj/structure/trench_wall/innercorners{
+	dir = 4
+	},
+/obj/structure/trench_wall/innercorners{
+	dir = 8;
+	pixel_x = 32
+	},
+/obj/structure/sign/warning/secure_area{
+	icon_state = "securearea2"
+	},
+/obj/hammereditor/nodraw,
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/red/hallway)
+"Ll" = (
+/turf/simulated/wall/perspectisub,
+/area/train/red)
+"Lm" = (
+/obj/machinery/computer/operating{
+	icon_state = "console"
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"Ln" = (
+/obj/structure/trench_wall{
+	dir = 10
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground)
+"Lq" = (
+/obj/structure/warfare/thehatch{
+	dir = 4
+	},
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/blue/room)
+"Ls" = (
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/stoneroom)
+"Lt" = (
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/stoneroom)
+"Lz" = (
+/obj/structure/defensive_barrier{
+	pixel_y = -4;
+	secured = 1
+	},
+/obj/hammereditor/nodraw,
+/turf/simulated/wall/perspecticrete,
+/area/warfare/battlefield/trench_section/underground)
+"LD" = (
+/obj/machinery/light/small/bunker{
+	dir = 8
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/room)
+"LE" = (
+/obj/machinery/light/small/bunker{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/machinery/camera{
+	dir = 4;
+	pixel_x = 2;
+	pixel_y = 0
+	},
+/turf/simulated/floor/wood,
+/area/warfare/homebase/red/caproom)
+"LI" = (
+/obj/machinery/light/caged{
+	pixel_y = 30;
+	pixel_x = 0
+	},
+/obj/structure/trench_wall{
+	dir = 4;
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/structure/table/rack/shelf/red,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/room)
+"LK" = (
+/obj/structure/trench_wall{
+	dir = 1
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/space)
+"LT" = (
+/obj/effect/floor_decal/trench{
+	dir = 4
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/one)
+"LV" = (
+/obj/structure/lattice,
+/obj/machinery/light/caged{
+	dir = 8;
+	pixel_x = 10;
+	pixel_y = 0
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/underground)
+"LW" = (
+/obj/item/device/flashlight/lantern{
+	on = 1;
+	pixel_x = -13;
+	pixel_y = -6
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/space)
+"LX" = (
+/obj/effect/floor_decal/trench,
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"Mb" = (
+/obj/machinery/light/caged{
+	pixel_y = 30;
+	pixel_x = 0
+	},
+/obj/structure/closet/crate/grenade,
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/room)
+"Mf" = (
+/obj/random/canned_food/red,
+/obj/random/canned_food/red,
+/obj/random/canned_food/red,
+/obj/structure/table/rack/shelf/red,
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/room)
+"Mg" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning/dust/corner{
+	dir = 1
+	},
+/obj/structure/train_deco/platform{
+	pixel_y = 16
+	},
+/obj/effect/lighting_dummy/daylight,
+/obj/effect/landmark/train_marker/teleport/blue,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/blue/trainyard)
+"Ml" = (
+/obj/machinery/light/caged{
+	pixel_y = -14;
+	dir = 1;
+	pixel_x = 0
+	},
+/obj/structure/trench_wall{
+	dir = 4;
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/structure/trench_wall/innercorners{
+	dir = 4;
+	pixel_x = -32;
+	pixel_y = -32
+	},
+/obj/structure/trench_wall/sequel{
+	dir = 5;
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/structure/closet/crate/club,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/room)
+"Mq" = (
+/obj/structure/sign/medholo,
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/red/stoneroom)
+"Mv" = (
+/obj/structure/warfare/thehatch{
+	dir = 4
+	},
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/red/room)
+"MB" = (
+/obj/item/storage/firstaid/surgery,
+/obj/structure/table/rack/nosmooth/metal,
+/obj/item/reagent_containers/spray/cleaner/warfare{
+	pixel_x = 4;
+	pixel_y = 18
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"MG" = (
+/obj/structure/closet/crate,
+/obj/random/canned_food/blue,
+/obj/random/canned_food/blue,
+/obj/random/canned_food/blue,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"MM" = (
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/trench_section/underground)
+"MP" = (
+/obj/hammereditor/nodraw/deco/shadowpaint{
+	opacity = 1;
+	dir = 4
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/trainyard)
+"MS" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/room)
+"MV" = (
+/obj/structure/defensive_barrier{
+	secured = 1;
+	dir = 8;
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/space)
+"MW" = (
+/obj/machinery/light/small/bunker{
+	dir = 1
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/stoneroom)
+"MZ" = (
+/obj/structure/trench_wall/sequel{
+	dir = 8
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/blue/two)
+"Nb" = (
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/homebase/red/hallway)
+"Nc" = (
+/obj/effect/floor_decal/trench{
+	dir = 10
+	},
+/obj/structure/stairs/trenchstairs,
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"Nd" = (
+/obj/structure/closet/crate/wooden{
+	pixel_x = -3;
+	pixel_y = 1
+	},
+/obj/structure/closet/crate/wooden{
+	pixel_x = -3;
+	pixel_y = 12
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
+"Nf" = (
+/obj/structure/train_deco/tracks01,
+/obj/hammereditor/nodraw/deco/shadowpaint{
+	opacity = 1;
+	dir = 8
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/trainyard)
+"Ng" = (
+/obj/structure/table/rack/nosmooth/metal,
+/obj/item/paper/crumpled{
+	info = "///// ///// ///// //";
+	pixel_x = -1;
+	pixel_y = 3;
+	contents = "///// ///// ///// //";
+	name = "Tally"
+	},
+/obj/item/storage/box/bodybags,
+/obj/item/pen/red{
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/room)
+"No" = (
+/obj/effect/landmark/start{
+	name = "Blue Squad Leader"
+	},
+/obj/machinery/light/small/bunker{
+	dir = 8
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/room)
+"Nq" = (
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/homebase/red/stoneroom)
+"Nr" = (
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/bunker)
+"Nt" = (
+/obj/structure/trench_wall{
+	dir = 10
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"Nv" = (
+/obj/structure/trench_wall/sequel{
+	dir = 8
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/red/one)
+"Nw" = (
+/obj/structure/train_deco/sides,
+/obj/effect/lighting_dummy/daylight,
+/obj/hammereditor/playerclip,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/trainyard)
+"Nz" = (
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"NA" = (
+/obj/machinery/light/small/bunker{
+	dir = 4
+	},
+/obj/structure/announcementspeaker/blue{
+	pixel_y = 0;
+	dir = 8
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"ND" = (
+/obj/structure/table/rack/shelf/red,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/largeroom)
+"NG" = (
+/obj/structure/banner/red/small{
+	pixel_y = 32
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"NH" = (
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/homebase/red/trainyard)
+"NI" = (
+/obj/effect/landmark/start{
+	name = "Red Soldier"
+	},
+/obj/structure/bed/chair/red{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 11;
+	buckle_pixel_shift = "x=0;y=11"
+	},
+/obj/machinery/light/caged{
+	pixel_y = -1;
+	dir = 1;
+	pixel_x = -16
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"NJ" = (
+/obj/structure/announcementspeaker/red{
+	pixel_x = 0;
+	dir = 1
+	},
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/homebase/red)
+"NM" = (
+/obj/machinery/kaos/cargo_machine/red,
+/turf/simulated/floor/wood,
+/area/warfare/homebase/red/caproom)
+"NN" = (
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/indoors)
+"NO" = (
+/obj/hammereditor/nodraw/deco/shutter_half{
+	dir = 4
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/room)
+"NP" = (
+/obj/structure/trench_wall,
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/indoors)
+"NQ" = (
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/room)
+"NT" = (
+/obj/structure/toilet{
+	dir = 4;
+	icon_state = "toilet00"
+	},
+/obj/structure/trench_wall{
+	dir = 4;
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/room)
+"NV" = (
+/obj/structure/toilet{
+	dir = 8;
+	icon_state = "toilet00"
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/room)
+"NW" = (
+/obj/structure/trench_wall/innercorners{
+	dir = 4
+	},
+/obj/structure/trench_wall/innercorners{
+	dir = 8;
+	pixel_x = 32
+	},
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/red/hallway)
+"NX" = (
+/obj/structure/trench_wall,
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/space)
+"NZ" = (
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/homebase/blue/div)
+"Oa" = (
+/obj/machinery/light/small/bunker{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"Ob" = (
+/obj/structure/trench_wall{
+	dir = 4
+	},
+/obj/structure/trench_wall{
+	dir = 6
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/indoors)
+"Ol" = (
+/obj/structure/banner/red/small{
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/trench{
+	dir = 4
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"Op" = (
+/obj/effect/landmark/start{
+	name = "Red Soldier"
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/hallway)
+"Os" = (
+/obj/hammereditor/nodraw/deco/shadowpaint{
+	opacity = 1;
+	dir = 4
+	},
+/turf/simulated/wall/perspecticrete,
+/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
+"Ot" = (
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/red/caproom)
+"Ow" = (
+/obj/structure/announcementspeaker/red{
+	pixel_x = 0;
+	dir = 4
+	},
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/battlefield/trench_section)
+"Ox" = (
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/fire,
+/obj/structure/table/rack/shelf/red,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/room)
+"Oy" = (
+/obj/structure/trench_wall/innercorners{
+	dir = 1
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/blue/two)
+"OA" = (
+/obj/random/canned_food/red,
+/obj/random/canned_food/red,
+/obj/structure/table/rack/shelf/red,
+/obj/random/canned_food/red,
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/room)
+"OB" = (
+/obj/structure/table/woodentable/shelf{
+	pixel_y = 13
+	},
+/obj/item/device/boombox/stationary{
+	pixel_x = 1;
+	pixel_y = 18
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/largeroom)
+"OC" = (
+/obj/effect/lighting_dummy/daylight,
+/obj/structure/train_deco/tracks01,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/trainyard)
+"OD" = (
+/obj/structure/trench_wall{
+	dir = 4
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/indoors)
+"OE" = (
+/obj/machinery/light/caged{
+	pixel_y = 30;
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/trench,
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/one)
+"OH" = (
+/obj/structure/train_deco/platform{
+	pixel_y = 3;
+	dir = 1
+	},
+/obj/hammereditor/playerclip,
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/trainyard)
+"OJ" = (
+/obj/item/device/compass,
+/obj/structure/table/rack/nosmooth/wood,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/room)
+"OK" = (
+/obj/hammereditor/nodraw/deco/shadowpaint,
+/obj/hammereditor/nodraw/deco/shadowpaint{
+	opacity = 1;
+	dir = 4
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/trainyard)
+"OL" = (
+/obj/machinery/light/small/bunker{
+	dir = 1
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/hallway)
+"OQ" = (
+/obj/structure/closet/crate{
+	pixel_x = 0;
+	pixel_y = -1
+	},
+/obj/structure/closet/crate{
+	pixel_x = 3;
+	pixel_y = 20
+	},
+/obj/effect/decal/cleanable/cobweb2{
+	dir = 1
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/room)
+"OR" = (
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/room)
+"OS" = (
+/obj/structure/trench_wall{
+	dir = 8
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/red/one)
+"OU" = (
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/stoneroom)
+"OX" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/hallway)
+"OY" = (
+/obj/machinery/light/caged{
+	dir = 4;
+	pixel_x = -1;
+	pixel_y = 0
+	},
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"Pd" = (
+/obj/structure/table/rack/shelf/red,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"Pg" = (
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/room)
+"Pi" = (
+/obj/machinery/light/small/bunker{
+	dir = 1
+	},
+/obj/structure/announcementspeaker/red{
+	pixel_x = 0;
+	dir = 8
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/hallway)
+"Pj" = (
+/obj/hammereditor/nodraw,
+/turf/simulated/floor/ert/metal01,
+/area/train/blue)
+"Pk" = (
+/obj/structure/curtain/tarp{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"Pq" = (
+/obj/effect/floor_decal/industrial/warning/dust,
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/red/trainyard)
+"Pt" = (
+/obj/effect/landmark/start{
+	name = "Red Squad Leader"
+	},
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/room)
+"Pw" = (
+/obj/machinery/light/caged{
+	pixel_y = 30;
+	pixel_x = 0
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"Px" = (
+/obj/structure/sign/neon/cargo,
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/red/largeroom)
+"Py" = (
+/obj/effect/landmark/start{
+	name = "Red Engineer"
+	},
+/obj/machinery/light/small/bunker{
+	dir = 1
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"Pz" = (
+/obj/structure/closet/crate{
+	pixel_x = -6;
+	pixel_y = 13
+	},
+/obj/structure/train_deco/platform{
+	pixel_y = 32;
+	dir = 4;
+	icon_state = "door_closed";
+	icon = 'icons/obj/doors/Doordoublesecglass1x2BLUE.dmi'
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/room)
+"PC" = (
+/obj/machinery/light/small/bunker{
+	dir = 1
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = 0;
+	pixel_y = 5
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = 8;
+	pixel_y = 5
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = 0;
+	pixel_y = 3
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = 8;
+	pixel_y = 3
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = -8;
+	pixel_y = 1
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = 0;
+	pixel_y = 1
+	},
+/obj/item/storage/toggle/envelope{
+	pixel_x = 8;
+	pixel_y = 1
+	},
+/obj/structure/table/nosmooth/capnew{
+	pixel_y = -4;
+	dir = 8
+	},
+/obj/structure/table/nosmooth/capnew{
+	pixel_y = 28;
+	dir = 9;
+	pixel_x = 0
+	},
+/obj/item/waxstamp{
+	pixel_x = -9;
+	pixel_y = 12
+	},
+/obj/item/flame/candle{
+	pixel_x = -10;
+	pixel_y = 19
+	},
+/obj/item/flame/candle{
+	pixel_x = -6;
+	pixel_y = 19
+	},
+/obj/item/flame/candle{
+	pixel_x = -8;
+	pixel_y = 19
+	},
+/obj/item/storage/box/matches{
+	pixel_x = 0;
+	pixel_y = 17
+	},
+/obj/structure/window/reinforced{
+	pixel_x = 0;
+	pixel_y = 7
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/largeroom)
+"PH" = (
+/obj/hammereditor/nodraw/deco/bars,
+/obj/hammereditor/nodraw/deco/bars{
+	pixel_y = 10
+	},
+/obj/hammereditor/nodraw,
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/space)
+"PI" = (
+/obj/structure/banner/red/small{
+	pixel_y = 32
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"PJ" = (
+/obj/sound_emitter/periodic/env_leak,
+/obj/effect/landmark/start{
+	name = "Red Soldier"
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/largeroom)
+"PS" = (
+/obj/structure/closet/secure_closet/medical1/warfare,
+/obj/item/clothing/suit/surgeon_apron,
+/obj/item/clothing/suit/surgeon_apron,
+/obj/item/clothing/suit/surgeon_apron,
+/obj/item/clothing/suit/surgeon_apron,
+/obj/item/storage/backpack/satchel/warfare/prac/blue,
+/obj/item/storage/backpack/satchel/warfare/prac/blue,
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"PV" = (
+/obj/machinery/sleeper{
+	dir = 4;
+	icon_state = "sleeper_0"
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"PZ" = (
+/obj/structure/warfare/thehatch{
+	dir = 4
+	},
+/obj/structure/trench_wall{
+	dir = 9;
+	pixel_y = 0;
+	layer = 28
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/indoors)
+"Qa" = (
+/obj/machinery/light/caged{
+	pixel_y = 30;
+	pixel_x = 0
+	},
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/battlefield/trench_section)
+"Qb" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/hallway)
+"Qc" = (
+/obj/machinery/light/caged{
+	pixel_y = -1;
+	dir = 1;
+	pixel_x = 0
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/one)
+"Qh" = (
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/room)
+"Qj" = (
+/obj/effect/landmark/start{
+	name = "Blue Soldier"
+	},
+/obj/structure/announcementspeaker/blue{
+	pixel_x = 0;
+	dir = 1
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"Qk" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/structure{
+	anchored = 1;
+	icon = 'icons/obj/modular_console.dmi';
+	icon_state = "console";
+	pixel_x = 6;
+	pixel_y = 3;
+	layer = 222
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/room)
+"Ql" = (
+/obj/item/flame/candle,
+/obj/item/storage/box/matches,
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 4
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"Qm" = (
+/obj/effect/floor_decal/trench{
+	dir = 6
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/one)
+"Qt" = (
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red)
+"Qu" = (
+/obj/item/device/compass,
+/obj/item/device/compass,
+/obj/item/device/compass,
+/obj/item/device/compass,
+/obj/item/device/compass,
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 6
+	},
+/obj/item/flame/candle/blue,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"Qx" = (
+/obj/hammereditor/playerclip,
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/trainyard)
+"Qy" = (
+/obj/effect/floor_decal/trench{
+	dir = 10
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"QA" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
+"QB" = (
+/obj/effect/structure{
+	anchored = 1;
+	icon = 'icons/obj/modular_console.dmi';
+	icon_state = "console";
+	layer = 222
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"QD" = (
+/obj/structure/dirt_wall,
+/obj/structure/announcementspeaker/blue{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/battlefield/trench_section/hallway)
+"QE" = (
+/obj/structure/warfare_itemeater/red{
+	pixel_y = 28
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/trench_section/underground)
+"QF" = (
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"QL" = (
+/obj/effect/darkout_teleporter/bluecoats,
+/turf/unsimulated/wall/submarine/doors,
+/area/train/blue)
+"QN" = (
+/obj/structure/railing/urban{
+	dir = 4
+	},
+/obj/effect/lighting_dummy/daylight,
+/obj/effect/floor_decal/industrial/warning/dust/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/dust/corner{
+	dir = 1
+	},
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/blue/trainyard)
+"QO" = (
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/battlefield/capture_point/blue/two)
+"QQ" = (
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/hallway)
+"QR" = (
+/obj/machinery/light/small/bunker{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/floor/wood,
+/area/warfare/homebase/red/caproom)
+"QS" = (
+/obj/machinery/light/caged{
+	dir = 8;
+	pixel_x = 10;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/trench{
+	dir = 5
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"QU" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 4
+	},
+/obj/effect/lighting_dummy/daylight,
+/obj/effect/landmark/train_marker/teleport/red,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/red/trainyard)
+"QW" = (
+/obj/structure/closet/crate/wooden{
+	pixel_x = 4;
+	pixel_y = -8
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/red/trainyard)
+"QZ" = (
+/obj/machinery/vending/medical{
+	req_access = newlist()
+	},
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/room)
+"Rb" = (
+/obj/hammereditor/nodraw,
+/turf/simulated/wall/perspecticrete,
+/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
+"Rc" = (
+/obj/structure/stairs/trenchstairs{
+	dir = 1
+	},
+/obj/structure/announcementspeaker/blue{
+	pixel_y = 32
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/two)
+"Rd" = (
+/obj/structure/banner/blue/small{
+	pixel_y = 32
+	},
+/obj/machinery/light/caged{
+	pixel_y = 30;
+	pixel_x = 0
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"Rg" = (
+/obj/machinery/light/small/bunker{
+	dir = 4
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/hallway)
+"Ri" = (
+/obj/structure/table/rack/holorack,
+/obj/structure/closet/crate,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/room)
+"Rj" = (
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/homebase/blue/trainyard)
+"Rk" = (
+/obj/item/flame/candle,
+/obj/item/flame/lighter/random,
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 4
+	},
+/obj/item/flame/candle/blue,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"Rl" = (
+/obj/hammereditor/nodraw,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/stoneroom)
+"Rn" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	icon_state = "rwindow"
+	},
+/obj/structure/window/reinforced,
+/obj/structure/cargo_pad/red,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/room)
+"Rr" = (
+/obj/effect/lighting_dummy/daylight,
+/obj/structure/train_deco/platform{
+	pixel_y = -32;
+	dir = 4;
+	icon_state = "door_closed";
+	icon = 'icons/obj/doors/Doordoublesecglass1x2BLUE.dmi'
+	},
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/blue/trainyard)
+"Rv" = (
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/structure/table/rack/shelf/red,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/room)
+"Ry" = (
+/obj/machinery/camera{
+	dir = 4;
+	pixel_x = 2;
+	pixel_y = 0
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"Rz" = (
+/obj/structure/train_deco/tracks01,
+/obj/effect/landmark/train_marker/idle/red,
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/trainyard)
+"RC" = (
+/obj/structure/sign/warning/secure_area{
+	icon_state = "securearea2"
+	},
+/obj/hammereditor/nodraw,
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/red/hallway)
+"RD" = (
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 6
+	},
+/obj/item/flame/candle{
+	pixel_x = -9;
+	pixel_y = 5
+	},
+/obj/item/flame/candle{
+	pixel_x = -5;
+	pixel_y = 12
+	},
+/obj/item/flame/candle{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/flame/candle{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/item/storage/firstaid/regular{
+	pixel_x = 7;
+	pixel_y = -1
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"RI" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
+	},
+/obj/effect/darkout_teleporter/bluecoats,
+/obj/effect/floor_decal/train_deco/stripes{
+	dir = 4
+	},
+/obj/effect/lighting_dummy/daylight,
+/obj/effect/landmark/train_marker/teleport/blue,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/blue/trainyard)
+"RK" = (
+/obj/structure/closet/crate/wooden/large{
+	icon_closed = "meatball";
+	icon_state = "meatball";
+	pixel_x = 4;
+	pixel_y = 0
+	},
+/obj/structure/closet/crate/wooden/large{
+	pixel_x = 29;
+	pixel_y = 25
+	},
+/obj/structure/closet/crate/wooden/large{
+	pixel_x = 4;
+	pixel_y = 25
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/red/trainyard)
+"RL" = (
+/obj/structure/trench_wall{
+	dir = 6
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/room)
+"RW" = (
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/toxin,
+/obj/structure/table/rack/shelf/red,
+/obj/structure/table/woodentable/shelf{
+	pixel_y = 26;
+	density = 0
+	},
+/obj/item/reagent_containers/glass/bottle/antique/slim/chloroform{
+	pixel_x = 10;
+	pixel_y = 32;
+	icon_state = "slim_rd"
+	},
+/obj/item/reagent_containers/rag{
+	pixel_x = -5;
+	pixel_y = 28
+	},
+/obj/item/reagent_containers/glass/bottle/antique/slim/chloroform{
+	pixel_x = 1;
+	pixel_y = 31;
+	icon_state = "slim_rd"
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"Sf" = (
+/obj/machinery/light/small/bunker{
+	dir = 1
+	},
+/obj/structure/announcementspeaker/blue{
+	pixel_x = 0;
+	dir = 1
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/stoneroom)
+"Sg" = (
+/obj/hammereditor/nodraw/deco/shadowpaint{
+	opacity = 1;
+	dir = 4
+	},
+/obj/structure/train_deco/tracks01,
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/trainyard)
+"Sh" = (
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
+"Si" = (
+/obj/machinery/light/caged{
+	pixel_y = 30;
+	pixel_x = 0
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/one)
+"Sl" = (
+/obj/machinery/optable{
+	dir = 8;
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"Sn" = (
+/obj/effect/floor_decal/trench{
+	dir = 9
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/two)
+"Sp" = (
+/obj/structure/trench_wall{
+	dir = 1;
+	pixel_y = -32
+	},
+/obj/structure/closet/body_bag,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"Sr" = (
+/obj/machinery/light/caged{
+	pixel_y = 28;
+	pixel_x = 0
+	},
+/turf/simulated/floor/wood,
+/area/warfare/homebase/blue)
+"Sy" = (
+/obj/effect/floor_decal/trench{
+	dir = 9
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"SD" = (
+/obj/machinery/light/caged{
+	pixel_y = -14;
+	dir = 1;
+	pixel_x = 0
+	},
+/obj/structure/trench_wall{
+	dir = 4;
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/structure/trench_wall/innercorners{
+	dir = 4;
+	pixel_x = -32;
+	pixel_y = -32
+	},
+/obj/structure/trench_wall/sequel{
+	dir = 5;
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/structure/closet/crate,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/room)
+"SI" = (
+/obj/structure/table/rack/nosmooth/metal,
+/obj/item/pen/blue{
+	pixel_x = -12;
+	pixel_y = 7
+	},
+/obj/item/paper/crumpled{
+	info = "///// ///// ///// //";
+	pixel_x = -1;
+	pixel_y = 3;
+	contents = "///// ///// ///// //";
+	name = "Tally"
+	},
+/obj/item/storage/box/bodybags,
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"SN" = (
+/obj/structure/trench_wall{
+	dir = 4
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/blue/two)
+"SO" = (
+/obj/machinery/light/caged{
+	pixel_y = -1;
+	dir = 1;
+	pixel_x = 0
+	},
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/battlefield/capture_point/blue/one)
+"SR" = (
+/obj/machinery/light/caged{
+	pixel_y = 30;
+	pixel_x = 0
+	},
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/battlefield/capture_point/blue/two)
+"SU" = (
+/obj/effect/floor_decal/trench{
+	dir = 6
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"SV" = (
+/obj/machinery/light,
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 4
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/hallway)
+"SX" = (
+/mob/living/simple_animal/hostile/retaliate/rat,
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"SY" = (
+/obj/machinery/light/small/bunker{
+	dir = 1
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/room)
+"SZ" = (
+/obj/effect/lighting_dummy/daylight,
+/obj/hammereditor/playerclip,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/trainyard)
+"Ta" = (
+/obj/item/storage/fancy/cigarettes,
+/obj/item/flame/lighter/random,
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 4
+	},
+/obj/item/flame/candle/blue,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"Td" = (
+/obj/machinery/camera{
+	dir = 8;
+	pixel_x = -2;
+	pixel_y = 0
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/red/trainyard)
+"Te" = (
+/obj/effect/floor_decal/newcorner/grey/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/newcorner/grey/corner{
+	dir = 1
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/hallway)
+"Th" = (
+/obj/structure/announcementspeaker/blue{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/homebase/blue)
+"Ti" = (
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/trainyard)
+"Tj" = (
+/obj/machinery/light/small/bunker{
+	dir = 8
+	},
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"Tk" = (
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/room)
+"Tm" = (
+/obj/structure/cargo_pad/red,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/room)
+"Tq" = (
+/obj/machinery/optable{
+	dir = 1;
+	pixel_x = -7
+	},
+/obj/machinery/light,
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/room)
+"Tr" = (
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/wood,
+/area/warfare/homebase/blue/caproom)
+"Tt" = (
+/obj/structure/table/nosmooth/capnew{
+	pixel_y = -4;
+	dir = 8
+	},
+/obj/item/clothing/accessory/medal/blue/stainless_steel{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/clothing/accessory/medal/blue/stainless_steel{
+	pixel_x = 12;
+	pixel_y = 2
+	},
+/obj/item/clothing/accessory/medal/blue/silver{
+	pixel_x = 16;
+	pixel_y = 2
+	},
+/obj/item/clothing/accessory/medal/blue/platinum{
+	pixel_x = 20;
+	pixel_y = 2
+	},
+/obj/item/device/megaphone/blue{
+	pixel_x = -1;
+	pixel_y = 6
+	},
+/obj/structure/table/nosmooth/capnew{
+	pixel_y = 28;
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/warfare/homebase/blue/caproom)
+"Tu" = (
+/obj/structure/closet/crate/medical,
+/obj/item/wirecutters,
+/obj/item/wirecutters,
+/obj/item/storage/firstaid/regular,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"Tv" = (
+/obj/item/storage/firstaid/surgery,
+/obj/item/reagent_containers/spray/cleaner/warfare/red{
+	pixel_x = 6;
+	pixel_y = 14
+	},
+/obj/structure/table/rack/nosmooth/metal,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"Tw" = (
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/largeroom)
+"Tx" = (
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/blue/hallway)
+"TE" = (
+/obj/structure/trench_wall{
+	dir = 4
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground)
+"TL" = (
+/obj/effect/landmark/start/redcoats,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 37
+	},
+/obj/structure/bed/chair/gray,
+/turf/simulated/floor/ert/metal01,
+/area/train/red)
+"TN" = (
+/obj/effect/floor_decal/trench{
+	dir = 1
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"TO" = (
+/obj/structure/table/rack/nosmooth/metal,
+/obj/item/reagent_containers/spray/cleaner/warfare/red{
+	pixel_x = -12;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/spray/cleaner/warfare/red{
+	pixel_x = 3;
+	pixel_y = 0
+	},
+/obj/item/reagent_containers/spray/cleaner/warfare/red{
+	pixel_x = -5;
+	pixel_y = 0
+	},
+/obj/item/reagent_containers/spray/cleaner/warfare/red{
+	pixel_x = 11;
+	pixel_y = 4
+	},
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/stoneroom)
+"TP" = (
+/obj/structure/bed/chair/throne{
+	pixel_y = -3;
+	buckle_pixel_shift = "x=0;y=-3"
+	},
+/obj/effect/landmark/start{
+	name = "Blue Captain"
+	},
+/turf/simulated/floor/wood,
+/area/warfare/homebase/blue/caproom)
+"TW" = (
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/room)
+"Ua" = (
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"Uc" = (
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/toxin,
+/obj/structure/table/rack/shelf/red,
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"Ue" = (
+/obj/structure/railing/urban{
+	dir = 4
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/red/trainyard)
+"Uf" = (
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/stoneroom)
+"Uh" = (
+/obj/effect/sub_marker/surface{
+	id = "MISSION"
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield)
+"Ui" = (
+/obj/structure/trench_wall{
+	dir = 8
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/blue/two)
+"Uj" = (
+/obj/structure/closet/crate/trashcart,
+/obj/machinery/light/caged{
+	pixel_y = -1;
+	dir = 1;
+	pixel_x = 0
+	},
+/turf/simulated/floor/trenches,
+/area/warfare/homebase/red)
+"Um" = (
+/obj/machinery/light/caged{
+	pixel_y = 30;
+	pixel_x = 0
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/two)
+"Un" = (
+/obj/structure/defensive_barrier{
+	secured = 1;
+	dir = 8;
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/space)
+"Ur" = (
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
+"Uv" = (
+/obj/effect/landmark/start/phoneoperator,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"Ux" = (
+/obj/effect/floor_decal/trench{
+	dir = 4
+	},
+/obj/structure/stairs/trenchstairs,
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"Uy" = (
+/obj/effect/floor_decal/trench,
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/one)
+"UC" = (
+/obj/structure/closet/crate,
+/obj/random/canned_food/blue,
+/obj/random/canned_food/blue,
+/obj/random/canned_food/blue,
+/obj/structure/table/rack/holorack,
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/room)
+"UD" = (
+/obj/structure/closet/crate/wooden/large{
+	icon_closed = "meatball";
+	icon_state = "meatball";
+	pixel_x = 4;
+	pixel_y = 0
+	},
+/obj/structure/closet/crate/wooden/large{
+	pixel_x = 29;
+	pixel_y = 25
+	},
+/obj/structure/closet/crate/wooden/large{
+	pixel_x = 4;
+	pixel_y = 25
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/blue/trainyard)
+"UI" = (
+/obj/structure/trench_wall/sequel{
+	dir = 8
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/bunker)
+"UJ" = (
+/obj/hammereditor/nodraw/deco/shadowpaint{
+	opacity = 1;
+	dir = 4
+	},
+/turf/simulated/floor/exoplanet/water/shallow/lightless/urban,
+/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
+"UK" = (
+/obj/structure/train_deco/platform{
+	pixel_y = 32;
+	dir = 4;
+	icon_state = "door_closed";
+	icon = 'icons/obj/doors/Doordoublesecglass1x2.dmi'
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/red/trainyard)
+"UM" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/red/trainyard)
+"UN" = (
+/obj/machinery/light/caged{
+	pixel_y = 30;
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/trench{
+	dir = 1
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"UP" = (
+/obj/structure/announcementspeaker/blue{
+	pixel_y = 0;
+	dir = 4
+	},
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/hallway)
+"UV" = (
+/obj/random/canned_food/blue{
+	pixel_x = -7;
+	pixel_y = 11
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/room)
+"UX" = (
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/fire,
+/obj/structure/table/rack/shelf/red,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"UY" = (
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/blue/stoneroom)
+"Vc" = (
+/obj/structure/dirt_wall,
+/turf/simulated/floor/dirty/tough,
+/area/warfare/battlefield/capture_point/blue/two)
+"Vd" = (
+/obj/hammereditor/nodraw/deco/shadowpaint{
+	opacity = 1;
+	dir = 1
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/trainyard)
+"Ve" = (
+/obj/structure/trench_wall{
+	dir = 4;
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/space)
+"Vf" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/hallway)
+"Vg" = (
+/obj/item/melee/classic_baton/factionbanner/blue,
+/turf/simulated/floor/tiled,
+/area/warfare/homebase/blue/largeroom)
+"Vi" = (
+/obj/machinery/sleeper{
+	dir = 4;
+	icon_state = "sleeper_0"
+	},
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/room)
+"Vj" = (
+/obj/structure/dirt_wall,
+/turf/simulated/floor/dirty/fake,
+/area/warfare/battlefield/capture_point/blue/one)
+"Vu" = (
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 32
+	},
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/room)
+"Vx" = (
+/obj/structure/cargo_pad/red,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/largeroom)
+"VC" = (
+/obj/structure/trench_wall{
+	dir = 5;
+	pixel_x = 32;
+	layer = 28
+	},
+/obj/structure/trench_wall/innercorners{
+	dir = 1;
+	pixel_x = 32;
+	pixel_y = 31
+	},
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"VE" = (
+/obj/machinery/door/airlock/multi_tile/metal/maintenance/red,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/hallway)
+"VJ" = (
+/obj/structure/closet/secure_closet/medical1/warfare,
+/obj/structure/announcementspeaker/red{
+	id = "Bluecoats";
+	pixel_y = 32
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"VL" = (
+/turf/unsimulated/wall/submarine/doors{
+	dir = 1
+	},
+/area/train/blue)
+"VO" = (
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"VP" = (
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/homebase/red)
+"VQ" = (
+/turf/simulated/wall/perspecticrete,
+/area/warfare/battlefield/trench_section/underground/stormsystem/hall)
+"VR" = (
+/obj/structure/announcementspeaker/blue{
+	pixel_y = 32
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"VS" = (
+/obj/item/storage/firstaid/surgery,
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 5
+	},
+/obj/item/flame/candle/blue,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"VT" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/stoneroom)
+"VZ" = (
+/obj/effect/landmark/start{
+	name = "Blue Squad Leader"
+	},
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/room)
+"Wa" = (
+/obj/machinery/bodyscanner{
+	dir = 4;
+	icon_state = "body_scanner_0"
+	},
+/obj/machinery/light/small/bunker{
+	dir = 4;
+	pixel_x = 0;
+	pixel_y = 15
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"Wf" = (
+/obj/structure/trench_wall{
+	dir = 10
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/room)
+"Wi" = (
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"Wj" = (
+/obj/structure/curtain,
+/obj/structure/curtain,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/room)
+"Wk" = (
+/obj/structure/trench_wall{
+	dir = 8
+	},
+/obj/structure/warfare/thehatch{
+	dir = 8
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/indoors)
+"Wl" = (
+/obj/effect/floor_decal/trench{
+	dir = 5
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"Wm" = (
+/obj/structure/vehicle/train/long_passenger{
+	pixel_y = 16;
+	id = "Redcoats"
+	},
+/turf/space,
+/area/space)
+"Wp" = (
+/obj/machinery/light/caged{
+	pixel_y = 28;
+	pixel_x = 0
+	},
+/obj/structure/closet/crate/trashcart,
+/turf/simulated/floor/trenches,
+/area/warfare/homebase/blue)
+"Wq" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/hallway)
+"Ws" = (
+/obj/structure/poster/red,
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/red/room)
+"Wu" = (
+/obj/machinery/sleeper,
+/obj/structure/trench_wall/innercorners{
+	dir = 4;
+	pixel_x = -32;
+	pixel_y = -32
+	},
+/obj/structure/trench_wall{
+	dir = 9;
+	pixel_x = -32;
+	layer = 28
+	},
+/obj/machinery/light/caged{
+	dir = 1;
+	pixel_y = -1
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"Ww" = (
+/turf/simulated/wall/perspecticrete,
+/area/warfare/homebase/red/stoneroom)
+"WD" = (
+/obj/structure/stairs/trenchstairs,
+/obj/structure/announcementspeaker/blue{
+	pixel_x = 0;
+	dir = 1
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"WF" = (
+/obj/structure/stairs/west,
+/obj/machinery/light/small/bunker{
+	dir = 1
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"WG" = (
+/obj/structure/trench_wall{
+	dir = 4;
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/structure/trench_wall/innercorners{
+	pixel_x = -32;
+	pixel_y = 31
+	},
+/obj/structure/stairs/trenchstairs{
+	dir = 1
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/two)
+"WH" = (
+/obj/structure/train_deco/tracks01,
+/obj/hammereditor/nodraw/deco/shadowpaint{
+	opacity = 1;
+	dir = 4
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/trainyard)
+"WJ" = (
+/obj/structure/announcementspeaker/red{
+	id = "Bluecoats";
+	pixel_y = 32
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/hallway)
+"WL" = (
+/obj/machinery/camera{
+	dir = 4;
+	pixel_x = 2;
+	pixel_y = 0
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/blue/trainyard)
+"WR" = (
+/obj/machinery/optable{
+	pixel_x = 4
+	},
+/obj/machinery/light,
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"WS" = (
+/obj/structure/trench_wall/innercorners{
+	dir = 1
+	},
+/obj/structure/trench_wall{
+	dir = 1
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/room)
+"WU" = (
+/obj/effect/floor_decal/trench{
+	dir = 9
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/one)
+"WX" = (
+/obj/structure/trench_wall{
+	dir = 4
+	},
+/obj/structure/warfare/thehatch{
+	dir = 4
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/indoors)
+"Xa" = (
+/obj/effect/landmark{
+	name = "tdome1"
+	},
+/obj/effect/ruin_loader/warfare_mid,
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/space)
+"Xb" = (
+/obj/structure/trench_wall{
+	dir = 4;
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/structure/table/rack/holorack,
+/obj/machinery/light/caged{
+	pixel_y = 30;
+	pixel_x = 0
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/room)
+"Xe" = (
+/obj/machinery/light/small/bunker{
+	dir = 1
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"Xf" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/hallway)
+"Xj" = (
+/obj/effect/floor_decal/stones{
+	dir = 8
+	},
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/battlefield/trench_section)
+"Xk" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 8
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/blue/trainyard)
+"Xl" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 8
+	},
+/obj/effect/lighting_dummy/daylight,
+/obj/effect/landmark/train_marker/teleport/red,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/red/trainyard)
+"Xn" = (
+/obj/machinery/light/small/bunker{
+	dir = 8
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/hallway)
+"Xu" = (
+/obj/machinery/door/airlock/bunker/red,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/largeroom)
+"Xx" = (
+/obj/effect/floor_decal/newcorner/grey/diagonal,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/hallway)
+"Xy" = (
+/obj/item/ammo_box/shotgun,
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 6
+	},
+/obj/item/flame/candle/blue,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"Xz" = (
+/obj/machinery/light/small/bunker{
+	dir = 4
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/hallway)
+"XA" = (
+/obj/machinery/light/small/bunker{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/warfare/homebase/red/caproom)
+"XC" = (
+/obj/structure/reagent_dispensers/coolanttank,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/room)
+"XD" = (
+/obj/structure/trench_wall/sequel{
+	dir = 4
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/bunker)
+"XH" = (
+/obj/structure/bed/chair/blue{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 11;
+	buckle_pixel_shift = "x=0;y=11"
+	},
+/turf/simulated/floor/wood,
+/area/warfare/homebase/blue/caproom)
+"XO" = (
+/obj/effect/floor_decal/trench{
+	dir = 10
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/trench_section/underground)
+"XS" = (
+/obj/structure/trench_wall/innercorners{
+	dir = 1
+	},
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/underground/bunker)
+"XX" = (
+/turf/simulated/floor/wood,
+/area/warfare/homebase/blue/caproom)
+"XY" = (
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 4
+	},
+/obj/structure/bed/chair/red{
+	pixel_x = -15;
+	pixel_y = 4
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"Yb" = (
+/obj/machinery/computer/operating{
+	icon_state = "console"
+	},
+/obj/machinery/light/caged{
+	dir = 1;
+	pixel_y = -1
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"Yd" = (
+/obj/effect/floor_decal/newcorner/grey/quarter,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/hallway)
+"Ye" = (
+/obj/structure/closet/crate/wooden{
+	pixel_x = -3;
+	pixel_y = 12
+	},
+/obj/structure/closet/crate/wooden{
+	pixel_x = -10;
+	pixel_y = 1
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/blue/trainyard)
+"Yh" = (
+/obj/structure/closet/crate,
+/obj/random/canned_food/blue,
+/obj/random/canned_food/blue,
+/obj/random/canned_food/blue,
+/obj/structure/table/rack/holorack,
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/room)
+"Yl" = (
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 4
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/largeroom)
+"Yn" = (
+/obj/effect/floor_decal/trench{
+	dir = 10
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/red/one)
+"Yt" = (
+/obj/structure/cargo_pad/bue/captain,
+/obj/structure/warfare_itemeater/blue{
+	pixel_y = 32
+	},
+/turf/simulated/floor/wood,
+/area/warfare/homebase/blue/caproom)
+"Yu" = (
+/turf/unsimulated/wall/submarine/doors{
+	dir = 4
+	},
+/area/train/red)
+"Yy" = (
+/obj/machinery/door/airlock/multi_tile/metal/maintenance/red{
+	locked = 1;
+	maxhealth = 500000
+	},
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/hallway)
+"Yz" = (
+/turf/simulated/floor/dirty/indestructable,
+/area/warfare/homebase/blue/trainyard)
+"YD" = (
+/obj/structure/table/rack,
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/stoneroom)
+"YE" = (
+/obj/structure/train_deco/tracks01,
+/obj/hammereditor/nodraw/deco/shadowpaint{
+	opacity = 1;
+	dir = 8
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/red/trainyard)
+"YJ" = (
+/obj/structure/train_deco/tracks01,
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/destroyed,
+/area/warfare/homebase/blue/trainyard)
+"YO" = (
+/obj/sound_emitter/periodic/env_leak,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/room)
+"YS" = (
+/obj/effect/landmark/test/safe_turf,
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/homebase/red)
+"YU" = (
+/obj/structure/closet/crate/wooden{
+	pixel_x = -3;
+	pixel_y = 12
+	},
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/concrete,
+/area/warfare/homebase/blue/trainyard)
+"YW" = (
+/obj/structure/trench_wall{
+	dir = 6
+	},
+/obj/structure/trench_wall,
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/trench_section/room)
+"Zb" = (
+/obj/item/device/flashlight{
+	on = 1;
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/room)
+"Zc" = (
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield)
+"Zf" = (
+/obj/structure/trench_wall{
+	dir = 1;
+	pixel_y = -32
+	},
+/obj/structure/closet/body_bag,
+/obj/effect/decal/cleanable/cobweb2{
+	dir = 8
+	},
+/obj/structure/trench_wall/innercorners{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = -32
+	},
+/turf/simulated/floor/wood,
+/area/warfare/battlefield/trench_section/underground/indoors)
+"Zi" = (
+/obj/structure/trench_wall{
+	dir = 4;
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/structure/trench_wall/innercorners{
+	pixel_x = -32;
+	pixel_y = 31
+	},
+/obj/structure/stairs/trenchstairs{
+	dir = 1
+	},
+/turf/simulated/floor/trenches/underground{
+	icon_state = "trench";
+	color = "#ffffff"
+	},
+/area/warfare/battlefield/capture_point/blue/one)
+"Zm" = (
+/obj/machinery/door/unpowered/simple/wood/captain{
+	initial_lock_value = "captain";
+	locked = 1
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/caproom)
+"Zo" = (
+/obj/structure/announcementspeaker/red{
+	id = "Bluecoats";
+	pixel_y = 32
+	},
+/turf/simulated/floor/urban/tiles/blue,
+/area/warfare/homebase/blue/room)
+"Zp" = (
+/obj/machinery/light/small/bunker{
+	dir = 1
+	},
+/obj/structure/announcementspeaker/blue{
+	pixel_x = 0;
+	dir = 1
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
+"Zr" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/simulated/floor/urban/tiles,
+/area/warfare/homebase/red/room)
+"Zs" = (
+/obj/structure/trench_wall/innercorners,
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/warfare/battlefield/capture_point/red/one)
+"Zu" = (
+/obj/structure/trench_wall/sequel{
+	dir = 8
+	},
+/obj/hammereditor/nodraw,
+/turf/simulated/mineral{
+	health = 999999
+	},
+/area/space)
+"Zz" = (
+/obj/effect/lighting_dummy/daylight,
+/turf/simulated/floor/urban/destroyed,
+/area/warfare/homebase/blue/trainyard)
+"ZB" = (
+/obj/effect/decal/cleanable/cobweb2{
+	dir = 8
+	},
+/obj/structure/cargo_pad{
+	pixel_x = 5;
+	pixel_y = -3
+	},
+/obj/structure/cargo_pad{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/structure/cargo_pad{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/structure/cargo_pad{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/blue/room)
+"ZF" = (
+/obj/structure/soldiercryo/special/red,
+/obj/machinery/light/small/bunker{
+	dir = 8
+	},
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/room)
+"ZI" = (
+/obj/structure/announcementspeaker/red{
+	pixel_x = 0;
+	dir = 8
+	},
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/red/hallway)
+"ZJ" = (
+/obj/item/device/compass,
+/obj/structure/table/rack/nosmooth/wood,
+/turf/simulated/floor/stones,
+/area/warfare/homebase/blue/room)
+"ZM" = (
+/obj/structure/announcementspeaker/blue{
+	pixel_x = 0;
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/warfare/homebase/blue/caproom)
+"ZP" = (
+/obj/machinery/door/airlock/multi_tile/metal/maintenance/blue,
+/turf/simulated/floor/concrete/random,
+/area/warfare/battlefield/trench_section/room)
+"ZQ" = (
+/obj/structure/announcementspeaker/red{
+	pixel_x = 0;
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/warfare/homebase/red/caproom)
+"ZV" = (
+/obj/hammereditor/nodraw,
+/turf/simulated/floor/urban/cinder,
+/area/warfare/homebase/red/room)
+"ZY" = (
+/obj/item/storage/box/matches,
+/obj/structure/table/rack/nosmooth/wood/alt{
+	dir = 4
+	},
+/obj/item/flame/candle/blue,
+/turf/simulated/floor/concrete/random,
+/area/warfare/homebase/blue/largeroom)
 
 (1,1,1) = {"
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjLlLlLlLlLlLlLlLlLlLlLlJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjFjFjFjFjFjFjFjFjFjFjFjJj
-JjLlneneTLneneneTLneneLlJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjFjFQFQFtFQFQFQFtFQFQFjJj
-JjqYcococococococococoYuJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjVLxpxpxpxpxpxpxpxpxpBUJj
-JjLlllrNllllcollllrNllLlJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjFjolzvololxpololzvolFjJj
-JjLlLlLlLlLlpxLlLlLlLlLlJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjFjFjFjFjFjQLFjFjFjFjFjJj
-JjEWEWEWEWtntntnEWEWEWEWJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjFcFcFcFcPjPjPjFcFcFcFcJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjBsJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjWmJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjaaaaaaaaaaaaaaaaaaaaaaJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjaaaaaaaaaaaaaaaaaaaaaaaaJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjaaaaaaCjCjCjaiCjCjCjpFaaJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjaaaaaaCjIhCRajgHTwcqpFaaJjJjJjJjJjJjJjJjJjJjJj
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaFXCOGDEowZTwAdpFaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaFXTwOBTwtbTwyKpFaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaNZNZNZNZNZNZNZNZNZNZaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaoNTwakTwcpTwyKpFaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaNZrMrMJvrMrMNZNZNZNZaaaaaaaaaaaaaaaaaaaaaaaaaaCjCjCjiKanalahzQCjCjCjCjCjCjCjCjCjCjCjCjaqaa
-aaaaaaaaaaNZrMBzhvSIrMNZNZNZNZaaaaaaaaaaaaaaaaaaaaaaaaaaCjlcRdxIblblvtKVuDCjCjHNMGWiekekWiOaWiCjaqaa
-aaaaaaaaaaNZLqrbmsbwrMNZNZNZNZaaaaaaaaaaaaaaaaaaaaaaaaaaCjHNWiWifaKVKVWiWiCjCjHNMGbtWiWiWiWiWiCjaqaa
-aaaaaaaaaaNZrMHebwRyrMNZNZNZNZaaaaaaaaaaaaaaaaaaaaaaaaaaCjbVhiWiXeXeWihiauCjCjEihiWiZpXeWihiuBCjaqaa
-NZNZNZrMrMrMrMrMrMvXrMAiAiAiNZNZNZNZNZaaaaaaaaaaaaaaaaaaCjaCaDWiCjCjWibsZYCjaibzaGWiCjCjWibzTaCjaqaa
-NZNZNZrMcHZoyhLmrMygyjWJeIAiNZNZNZNZNZaaaaaaaaaaaaaaaaaaCjVSaFWiCjCjWiaKXyCjCjaHGAWiCjCjWiaMaNCjaqaa
-NZNZNZrMcHbwmsbwrMwuwuwueIAiNZNZNZNZNZaaaaaaaaaaaaaaaaaaCjvPfrbtOaOaWifrawCjCjHmfrWiOaOaWifrawCjaqaa
-NZNZNZrMcHbwbwcZrMXfwuwurMrMrMrMAXNZNZaaaaaaaaaaaaaaaaaaCjWiWiWiWiWiWiWiWiCjCjWiWiWiWiWiWiWiaSCjaqaa
-NZNZNZrMrMrMDfrMrMwuwuwurMmUPSrMrMNZNZaaaaaaaaaaaaaaaaaaCjexmoWiWiWiWiWiWiususWiWiWiWiWiWibtaSCjaqaa
-NZNZNZwXZoIchHJcbwwuwuwuDfvkbwUXrMNZNZaaaaaaaaaaaaaaaaaaCjCjCjCjHcWiWiWibtaUVgWiWiWiWiWiWiWiWiCjaqaa
-NZNZNZrMrMrMDfrMrMwuwuVfrMmsbwUcrMNZNZaaaaaaaaaaaaaaaaaaaqaqCjaVWiWiWiWiWiWiWiWiWiWiWiWiWiWiWiCjaqaa
-NZNZNZrMVJUabwyZrMeDwuAlDfbwbwnirMNZNZaaaaaaaaaaaaaaaaaaaqaqCjWFWiWiWiWiXedfWiWiXeWiWidfXeWiWiCjaqaa
-NZNZNZrMcHbwmsbwrMwuwuwurMxqetrMrMNZNZaaaaaaaaaaaaaaaaaaaqaqrMrMrMrMWjrMrMrMWjrMrMrMWjrMrMrMWjrMrMaa
-NZNZNZrMcHbwWRLmrMwuwuwurMrMrMrMAXNZNZaaaaaaaaaaaaaaaaaaaqaqAXAXrMaYotaYrMaYotaYrMaYotrKrMaYotrKrMaa
-NZNZNZgggggggggggguHwuwubbNZNZNZNZNZNZaaaaaaaaaaaaaaaaaaaqaqAXAXrMotvKNVrMotvKNVrMotvKotrMotvKotrMaa
-ShVQHyHyHyHyHyHyRbeveFevRbVQVQVQOsvoShaaaaaaaaaaaaaaaaaaaqaqAXAXrMpXayaJrMpXayaJrMpXayaJrMpXayaJrMaa
-VQVQHyBEHyFYiXHyATUrHyHyATHywGwGwevoShaaaaaaaaaaaaaaaaaaaqaqAXAXrMrMrMrMrMrMrMrMrMrMrMrMrMrMrMrMrMaa
-VQABABABABABABABABABABABABABABABUJvoShaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-VQVQQAFYABsUcUAONdoopuwGwGwGwGwGwevoShaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-ShVQVQFYABeGVQVQVQVQVQrVrVrVVQVQOsvoShaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-ShShVQFYABwGVQShShShVQQAHyQAVQShShShShaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-ShShVQHyABwGVQShShShVQVQFSVQVQShShShShaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-ShShVQHyABwGVQShShaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-ShShVQHyABwGVQShShaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-ShShVQHyABwGShShShaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-ShShVQHyABwGShShShaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-ShShVQHyABShShShShaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-ShShVQHyABShShShShaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-ShShVQHyShShShShShaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-ShShVQHyShShShShShaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaaaaaaaaaaaaaaaaaaaaaaaaaaFkIeIesWaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaaaaaaaaaaaaaaaaaaaaaaaaaazgGuGusAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaaDcNXNXNXNXNXNXNXNXNXNXHqTEzUzUyoxCNXNXNXNXNXNXNXNXNXNXzAaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaazgbdbdbdbdbdbdbdRcbdbdyoTEncLVyoTEbdbdRcbdbdbdbdbdbdbdsAaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaazgbhFEqbEcbkqbIgbkmTbkyoTEqxqfyoTEhqnxSnzDbkcGzscGnxSnsAaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaazgHobkdldlZPNQdldlnxSnAWLnLzLzAWLnqbbkdldlZPNQdldlbkbhsAaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaazgbkhqdlwlNQNQMbdlbkbhSnUmbkmTnnSnbhcGdlvMBuNQIpdlbkbksAaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaazgcgcgdljTNQNQjTdlcgcgcgcgqbbkcgcgcgcgdldpNQNQxZdlcgcgsAaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaakszqzqdldvkeUCdvdlzqzqzqMZbkqbikzqzqzqdldlaRaWdldlzqzqnAaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaaaacncndldldldldldlcncncnSNcGFEUicncncncndldldldlcncncnaaaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaaaacncncncncncncncncnrfuzJGCGyGdjuzOycncncncncncncncncnaaaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaaaaaaDaNPNPDaNPNPNPNPODCYMMMMJTMMaoeANPNPNPNPDaNPNPNNaaaaaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaaaaaaODlXgIIQnNEkKvgFIQoEMMhBDBMMIdsrjZEkKvnNObnyCmeAaaaaaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaaaaaaODVOVOPkVOVOVOVOjOXOMMyoTEMMiVPkVOVOjcVOjOVOVOeAaaaaaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaaaaaaWXAsyAxjjcVOVOVOwFarMMAWLnMMgvdHVOVOVOVOFqoTKHWkaaaaaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaaaaaawoFCFCqkFgqqSlkwODMMMMqErqMMMMeAWuMBSlkwGXFCFCNNaaaaaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaaaacKcKyHzzzzaTaTWSlfzRlfnKiUQSpZlfqHJUJUzOaTzzkbQhcKcKaaaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaaaacKcKQhXbcPYheXQhcKcKcKlsnzDKeScKcKcKyHWfbTdKRLkbcKcKaaaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaaDcbobokbcVTWTWdOQhboboboNtIZuWctboboboQhNTORTWkSQhbobozAaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaazgdbyveOMlTWTWlOQhZidbdbdbDKIZdbdbdblIQhdQTWTWqIQhCddbsAaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaazgDKDKRLWfkZTWRLWfcFIZcxphTNefujIZefSURLWfkZTWRLWfIZefsAaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaazgasuWpGdeIZcxdernDKefXDNrNrNrNrUIDKIZpmczIZTNwcpmTNqgsAaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaazgDKSUnzefDKnzcxDKTNDKvaNrNrNrNramcxcFIZuWDKuWDKuWcxDKsAaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaazgUxdgdgdgdgdgdgWDdgdgvaNrNrNrNramdgdgWDdgdgdgdgdgdghIsAaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaaksLKLKLKLKLKLKLKLKLKLKnJNrNrNrNrbDLKLKLKLKLKLKLKLKLKLKnAaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-ShShShShShShShShShaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaDcNXNXNXNXNXNXNXNXNXNXXSNrNrNrNrFyNXNXNXNXNXNXNXNXNXNXzAaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaazgdhdhdhdhdhdhdhHHdhdhvaNrNrNrNramdhdhHHdhdhdhdhdhdhdhsAaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaazgUyQmCICTpLCIlBpLDRpLvaNrNrNrNramLTKgWUhwpLYnQcYnKgWUsAaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaazgdkpLdldldTNQdldlKgWUIkNrNrNrNrxVCIpLdldldTNQdldlpLUysAaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaazgpLLTdldoBuNQwldlpLUyWUSipLDROEWUUyYndlFwNQNQIpdlpLpLsAaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaazgdrdrdldsNQNQyxdldrdrdrdrCIpLdrdrdrdrdldpNQNQxZdldrdrsAaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaksmDmDdlsLMfOAsLdlmDmDmDNvpLCIdxmDmDmDdldldydzdldlmDmDnAaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaadididldldldldldldididiKuYnQmOSdididiQhdldldldlQhdidiaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaadidiQhQhQhQhQhQhdiZsoReRreJHquoRosdiQhQhQhQhQhQhdidiaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaNNNNDaNPxLNPNPNPNNNPNPDaNPNPduNPODCYMMMMoBMMaoeANPNPduNPDaNPNPNNNNNNNNNNaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaNNNNIQzaVOjviZqGhhmXVCIQnNRWnvgFIQoEMMhBDBMMpvsrjZsznvnNObnyCmeANNNNNNNNaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaNNNNvSVOVOiZiZiZytVOVOPkVOVOVOVOjOXOMMyoTEMMiVPkVOVOVOVOjOVOVOeANNNNNNNNaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaNNNNxjFpSpSpSpZfPZHUomxjVOVOVOVOxjarMMAWLnMMgvjyVOVOVOVOFqchKHWkNNNNNNNNaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaNNNNwoNNNNNNNNNNwoFCFCODFgTvvCYbODMMMMqQQEMMMMeAWuTvvCkwGXFCFCNNNNNNNNNNaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaadAdAyHzzzzaTaTWSJUdAdAtumNxxjWuNlyFCFCzOaTzzkbQhdAdAaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaVeemaadAdAQhLItTjudFQhdAdAdAvdWlQFyTdAdAdAyHWfdJdKYWkbdAdAaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaNXNXwKheemDcrIrIkbcwTWTWHOQhrIrIrIdPSyQyBDrIrIrIQhNTTWORkSQhrIrIzAaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaheheheheemzgdSxWeOSDTWTWdCQhWGdSdSdSQFSydSdSdSumQhdQTWTWqIQhntdSsAaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaheheheqTAKtWQFQFRLWfCrTWRLWftcSywJwqHQLXcASyLXBHRLWfCrTWRLWfSyLXsAaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaFxhehehePHatQyUNNGSywJNGkzQFLXhBDBoKoKhBDBQFSyPwOlSyHQdWPwHQSXsAaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaazgheheemZuQFBHWlLXQFWlwJQFHQQFyoLnMMMMyoTEwJtcSyQyQFQyQFQywJQFsAaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaARheemzgbPdXdXdXdXdXdXacdXdXyoMMKYMMAWTEdXdXacdXdXdXdXdXdXNcsAaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaazgFZemksLKLKLKLKLKLKLKLKLKLKsBMMMMMMMMBoLKLKLKLKLKLKLKLKLKLKnAaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaazgheemaaaaaaaaaaaaaaaaaaaaaacBDBvuvuhBcBaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaazgheheheaaaaaaaaaaaaaaaaaaaacBTEMMcBcBcBaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaheheheaaaaaaaaaaaaaaaaaacBTEMMcBcBcBaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaanQnQnQnQnQnQaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaanQcsvnAHALnQaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaanQVOVOVOVOnQaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaBrBrBrbgBrBrBrpFaaaaaaaanQulqjUvtAnQaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaBrDqapTmucadFLpFaaaaaaaanQoyVOVOlEnQaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarBKxRnVxEMadjrpFaaaaaaaanQnQnQnQnQnQaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaauAuAuArBadtgaddwadNDBruAuAaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaauAuAuAIzadaeadqLadNDBruAuAaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaauABrBrBrPCbmafPxXuBrBrBrBrBrBrBrBrBrBrBrBraaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaauABriQPIlKpSpSPJbqvhBrBrBibuGOJLJXGONzdnBraaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaauABrBidndnbqbqbqdndnBrBrBibudndndndndndnBraaaa
-aaaaVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPaaaaaaaaaaaauABrohmfdnzBzBNzmfIXBrBrohmfdnzBzBdnmfIXBraaaa
-aaaaVPVPVPVPVPVPFrFrqDFrFrFrFrFrFrFrVPVPVPaaaaaaaaaaaauABrHTbCdnBrBrdnyBQlBrBrpdbFNzBrBrdnpdbGBraaaa
-aaaaVPVPVPVPVPVPFrEUMSNgFrijVuItzeFrVPVPVPaaaaaaaaaaaauABrbHvgdnBrBrdnHfxKBrBrhguCdnBrBrdnbLbMBraaaa
-aaaaVPVPVPVPVPVPMvZrAgItFrptAgItzeFrVPVPVPaaaaaaaaaaaauABrlxbOdnGOGOdnbODJBrBrlxbOdnGOGOdnbODJBraaaa
-aaaaVPVPVPVPVPVPFritHjegFrFbTqItzeFrVPVPVPaaaaaaaaaaaauABrdndndndndndndndnBrBrdndndndndndndnBcBraaaa
-aaaaVPVPVPVPVPVPFrFrFrnbFrFrFrFPFrFrabVPVPaaaaaaaaaaaaBrBrmJPddndndndndndnxRxRdndndndndnNzdnBcBraaaa
-aaaaVPVPVPFrFrFrjPxccRvlItAotsqlEUItebVPVPaaaaaaaaaaaajPjPjPjPCeNzdndndndnbSqFdndndndndndndndnBraaaa
-aaaaVPVPFrFruwuwjPwRwRwRFrFrFrFPFrFrabVPVPaaaaaaaaaaaajPdZrTtkdndndndndndndndndndndndndndndndnBraaaa
-aaaaVPVPFrOxItItewwRwRwRFrijiDItzeFrVPVPVPaaaaaaaaaaaajPdZsEtkzBdndnnVzBdnNzdnzBdndnnVzBdndndnBraaaa
-aaaaVPVPFrfpAgItjPejwRwRFrptAgItzeFrVPVPVPaaaaaaaaaaaajPjPjPjPFrFryPFrFrFryPFrFrFryPFrFrFryPFrFraaaa
-aaaaVPVPFrRvHjItewwRxcWqFrFbTqHjzeFrVPVPVPaaaaaaaaaaaaVPVPVPVPFrwzbYwzFrwzbYwzFrwzbYcSFrIWbYcSFraaaa
-aaaaVPVPFrFrbJQZjPwRwRwRFrFrFrFrFrFrVPVPVPaaaaaaaaaaaaVPVPVPVPFrcacbccFrrmcbccFrcacbcdFrcacbcdFraaaa
-aaaaVPVPVPFrFrFrjPQbwRwRiyWwVPVPVPVPVPVPVPaaaaaaaaaaaaVPVPVPVPFrcjmlclFrcjmlclFrcjmlclFrcjmlclFraaaa
-eaeaKBimimimVPVPjPwRwRwRiyWwVPVPVPVPVPVPVPaaaaaaaaaaaaVPVPVPVPFrWsFrFrFrFrFrFrFrFrFrFrFrFrFrFrFraaaa
-eaXaKBimimimVPVPjPjPjPjPWwWwVPVPVPVPVPVPVPaaaaaaaaaaaaVPVPVPVPNqNqNqNqNqNqNqNqNqNqNqNqNqNqNqNqNqaaaa
-eaeaKBimimimVPVPYSiqVPKyVPVPVPVPVPVPVPVPVPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NZ
+NZ
+NZ
+NZ
+NZ
+NZ
+NZ
+NZ
+NZ
+NZ
+NZ
+Sh
+VQ
+VQ
+VQ
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ea
+ea
+ea
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
 "}
+(2,1,1) = {"
+Jj
+Ll
+Ll
+qY
+Ll
+Ll
+EW
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NZ
+NZ
+NZ
+NZ
+NZ
+NZ
+NZ
+NZ
+NZ
+NZ
+NZ
+VQ
+VQ
+AB
+VQ
+VQ
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ea
+Xa
+ea
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(3,1,1) = {"
+Jj
+Ll
+ne
+co
+ll
+Ll
+EW
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NZ
+NZ
+NZ
+NZ
+NZ
+NZ
+NZ
+NZ
+NZ
+NZ
+NZ
+Hy
+Hy
+AB
+QA
+VQ
+VQ
+VQ
+VQ
+VQ
+VQ
+VQ
+VQ
+VQ
+VQ
+VQ
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+KB
+KB
+KB
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(4,1,1) = {"
+Jj
+Ll
+ne
+co
+rN
+Ll
+EW
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rM
+rM
+rM
+rM
+rM
+wX
+rM
+rM
+rM
+rM
+gg
+Hy
+BE
+AB
+FY
+FY
+FY
+Hy
+Hy
+Hy
+Hy
+Hy
+Hy
+Hy
+Hy
+Hy
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+im
+im
+im
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(5,1,1) = {"
+Jj
+Ll
+TL
+co
+ll
+Ll
+EW
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rM
+cH
+cH
+cH
+rM
+Zo
+rM
+VJ
+cH
+cH
+gg
+Hy
+Hy
+AB
+AB
+AB
+AB
+AB
+AB
+AB
+AB
+AB
+AB
+AB
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+Fr
+Fr
+Fr
+Fr
+Fr
+VP
+im
+im
+im
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(6,1,1) = {"
+Jj
+Ll
+ne
+co
+ll
+Ll
+tn
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+NZ
+NZ
+NZ
+NZ
+NZ
+rM
+Zo
+bw
+bw
+rM
+Ic
+rM
+Ua
+bw
+bw
+gg
+Hy
+FY
+AB
+sU
+eG
+wG
+wG
+wG
+wG
+wG
+wG
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NN
+NN
+NN
+NN
+NN
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+VP
+VP
+VP
+VP
+VP
+Fr
+Fr
+Ox
+fp
+Rv
+Fr
+Fr
+im
+im
+im
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(7,1,1) = {"
+Jj
+Ll
+ne
+co
+co
+px
+tn
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+NZ
+rM
+rM
+Lq
+rM
+rM
+yh
+ms
+bw
+Df
+hH
+Df
+bw
+ms
+WR
+gg
+Hy
+iX
+AB
+cU
+VQ
+VQ
+VQ
+VQ
+VQ
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NN
+NN
+NN
+NN
+NN
+aa
+aa
+NX
+he
+he
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+VP
+VP
+VP
+VP
+VP
+Fr
+uw
+It
+Ag
+Hj
+bJ
+Fr
+VP
+VP
+VP
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(8,1,1) = {"
+Jj
+Ll
+ne
+co
+ll
+Ll
+tn
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+NZ
+rM
+Bz
+rb
+He
+rM
+Lm
+bw
+cZ
+rM
+Jc
+rM
+yZ
+bw
+Lm
+gg
+Hy
+Hy
+AB
+AO
+VQ
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Da
+IQ
+vS
+xj
+wo
+aa
+aa
+NX
+he
+he
+Fx
+zg
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+VP
+VP
+VP
+VP
+VP
+Fr
+uw
+It
+It
+It
+QZ
+Fr
+VP
+VP
+VP
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(9,1,1) = {"
+Jj
+Ll
+TL
+co
+ll
+Ll
+EW
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+NZ
+Jv
+hv
+ms
+bw
+rM
+rM
+rM
+rM
+rM
+bw
+rM
+rM
+rM
+rM
+gg
+Rb
+AT
+AB
+Nd
+VQ
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NP
+za
+VO
+Fp
+NN
+aa
+aa
+wK
+he
+he
+he
+he
+AR
+zg
+zg
+zg
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+Fr
+Fr
+Mv
+Fr
+Fr
+jP
+jP
+ew
+jP
+ew
+jP
+jP
+jP
+jP
+YS
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(10,1,1) = {"
+Jj
+Ll
+ne
+co
+rN
+Ll
+EW
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+NZ
+rM
+SI
+bw
+Ry
+vX
+yg
+wu
+Xf
+wu
+wu
+wu
+eD
+wu
+wu
+uH
+ev
+Ur
+AB
+oo
+VQ
+Sh
+Sh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+xL
+VO
+VO
+Sp
+NN
+aa
+Ve
+he
+he
+qT
+he
+he
+he
+FZ
+he
+he
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+Fr
+EU
+Zr
+it
+Fr
+xc
+wR
+wR
+ej
+wR
+wR
+Qb
+wR
+jP
+iq
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(11,1,1) = {"
+Jj
+Ll
+ne
+co
+ll
+Ll
+EW
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+NZ
+rM
+rM
+rM
+rM
+rM
+yj
+wu
+wu
+wu
+wu
+wu
+wu
+wu
+wu
+wu
+eF
+Hy
+AB
+pu
+VQ
+VQ
+VQ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NP
+jv
+iZ
+Sp
+NN
+aa
+em
+em
+em
+AK
+he
+em
+em
+em
+em
+he
+he
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+qD
+MS
+Ag
+Hj
+Fr
+cR
+wR
+wR
+wR
+xc
+wR
+wR
+wR
+jP
+VP
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(12,1,1) = {"
+Jj
+Ll
+Ll
+Yu
+Ll
+Ll
+EW
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+NZ
+NZ
+NZ
+NZ
+NZ
+Ai
+WJ
+wu
+wu
+wu
+wu
+Vf
+Al
+wu
+wu
+wu
+ev
+Hy
+AB
+wG
+rV
+QA
+VQ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Dc
+zg
+zg
+zg
+zg
+zg
+ks
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Dc
+zg
+zg
+zg
+zg
+zg
+ks
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Dc
+zg
+zg
+zg
+zg
+zg
+ks
+aa
+aa
+NP
+iZ
+iZ
+Sp
+NN
+aa
+aa
+Dc
+zg
+tW
+PH
+Zu
+zg
+ks
+aa
+he
+he
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+Fr
+Ng
+It
+eg
+nb
+vl
+wR
+wR
+wR
+Wq
+wR
+wR
+wR
+jP
+Ky
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(13,1,1) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+NZ
+NZ
+NZ
+NZ
+NZ
+Ai
+eI
+eI
+rM
+rM
+Df
+rM
+Df
+rM
+rM
+bb
+Rb
+AT
+AB
+wG
+rV
+Hy
+FS
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+bd
+bh
+Ho
+bk
+cg
+zq
+cn
+cn
+aa
+aa
+aa
+aa
+aa
+cK
+cK
+bo
+db
+DK
+as
+DK
+Ux
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+dh
+Uy
+dk
+pL
+dr
+mD
+di
+di
+NP
+qG
+iZ
+Zf
+NN
+dA
+dA
+rI
+dS
+QF
+at
+QF
+bP
+LK
+aa
+aa
+he
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+Fr
+Fr
+Fr
+Fr
+Fr
+It
+Fr
+Fr
+Fr
+Fr
+Fr
+iy
+iy
+Ww
+VP
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(14,1,1) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+NZ
+NZ
+NZ
+NZ
+NZ
+Ai
+Ai
+Ai
+rM
+mU
+vk
+ms
+bw
+xq
+rM
+NZ
+VQ
+Hy
+AB
+wG
+rV
+QA
+VQ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+bd
+FE
+bk
+hq
+cg
+zq
+cn
+cn
+Da
+OD
+OD
+WX
+wo
+cK
+cK
+bo
+yv
+DK
+uW
+SU
+dg
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+dh
+Qm
+pL
+LT
+dr
+mD
+di
+di
+NN
+hh
+yt
+PZ
+wo
+dA
+dA
+rI
+xW
+QF
+Qy
+BH
+dX
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+Fr
+ij
+pt
+Fb
+Fr
+Ao
+Fr
+ij
+pt
+Fb
+Fr
+Ww
+Ww
+Ww
+VP
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(15,1,1) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+NZ
+NZ
+NZ
+NZ
+NZ
+NZ
+NZ
+NZ
+rM
+PS
+bw
+bw
+bw
+et
+rM
+NZ
+VQ
+wG
+AB
+wG
+VQ
+VQ
+VQ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+bd
+qb
+dl
+dl
+dl
+dl
+dl
+cn
+NP
+lX
+VO
+As
+FC
+yH
+Qh
+kb
+eO
+RL
+pG
+nz
+dg
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+dh
+CI
+dl
+dl
+dl
+dl
+dl
+Qh
+NP
+mX
+VO
+HU
+FC
+yH
+Qh
+kb
+eO
+RL
+UN
+Wl
+dX
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+Fr
+Vu
+Ag
+Tq
+Fr
+ts
+Fr
+iD
+Ag
+Tq
+Fr
+VP
+VP
+VP
+VP
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(16,1,1) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NZ
+NZ
+NZ
+rM
+rM
+UX
+Uc
+ni
+rM
+rM
+NZ
+VQ
+wG
+AB
+wG
+VQ
+Sh
+Sh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+bd
+Ec
+dl
+wl
+jT
+dv
+dl
+cn
+NP
+gI
+VO
+yA
+FC
+zz
+Xb
+cV
+Ml
+Wf
+de
+ef
+dg
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+dh
+CT
+dl
+do
+ds
+sL
+dl
+Qh
+NP
+VC
+VO
+om
+FC
+zz
+LI
+cw
+SD
+Wf
+NG
+LX
+dX
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+Fr
+It
+It
+It
+FP
+ql
+FP
+It
+It
+Hj
+Fr
+VP
+VP
+VP
+VP
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(17,1,1) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NZ
+NZ
+NZ
+AX
+rM
+rM
+rM
+rM
+rM
+AX
+NZ
+Os
+we
+UJ
+we
+Os
+Sh
+Sh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+bd
+bk
+ZP
+NQ
+NQ
+ke
+dl
+cn
+Da
+IQ
+Pk
+xj
+qk
+zz
+cP
+TW
+TW
+kZ
+IZ
+DK
+dg
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+dh
+pL
+dT
+Bu
+NQ
+Mf
+dl
+Qh
+Da
+IQ
+Pk
+xj
+OD
+zz
+tT
+TW
+TW
+Cr
+Sy
+QF
+dX
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+Fr
+ze
+ze
+ze
+Fr
+EU
+Fr
+ze
+ze
+ze
+Fr
+VP
+VP
+VP
+VP
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(18,1,1) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NZ
+NZ
+NZ
+NZ
+NZ
+NZ
+NZ
+NZ
+NZ
+NZ
+NZ
+vo
+vo
+vo
+vo
+vo
+Sh
+Sh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+bd
+qb
+NQ
+NQ
+NQ
+UC
+dl
+cn
+NP
+nN
+VO
+jc
+Fg
+aT
+Yh
+TW
+TW
+TW
+cx
+nz
+dg
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+dh
+CI
+NQ
+NQ
+NQ
+OA
+dl
+Qh
+NP
+nN
+VO
+VO
+Fg
+aT
+ju
+TW
+TW
+TW
+wJ
+Wl
+dX
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+Fr
+Fr
+Fr
+Fr
+Fr
+It
+Fr
+Fr
+Fr
+Fr
+Fr
+VP
+VP
+VP
+VP
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(19,1,1) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NZ
+NZ
+NZ
+NZ
+NZ
+NZ
+NZ
+NZ
+NZ
+NZ
+NZ
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+Sh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+bd
+Ig
+dl
+Mb
+jT
+dv
+dl
+cn
+NP
+Ek
+VO
+VO
+qq
+aT
+eX
+dO
+lO
+RL
+de
+cx
+dg
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+dh
+lB
+dl
+wl
+yx
+sL
+dl
+Qh
+NP
+RW
+VO
+VO
+Tv
+aT
+dF
+HO
+dC
+RL
+NG
+wJ
+dX
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+VP
+VP
+VP
+VP
+ab
+eb
+ab
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(20,1,1) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+Rc
+bk
+dl
+dl
+dl
+dl
+dl
+cn
+NP
+Kv
+VO
+VO
+Sl
+WS
+Qh
+Qh
+Qh
+Wf
+rn
+DK
+WD
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+HH
+pL
+dl
+dl
+dl
+dl
+dl
+Qh
+du
+nv
+VO
+VO
+vC
+WS
+Qh
+Qh
+Qh
+Wf
+kz
+QF
+ac
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(21,1,1) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+bd
+mT
+nx
+bk
+cg
+zq
+cn
+cn
+NP
+gF
+VO
+VO
+kw
+lf
+cK
+bo
+Zi
+cF
+DK
+TN
+dg
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+dh
+DR
+Kg
+pL
+dr
+mD
+di
+di
+NP
+gF
+VO
+VO
+Yb
+JU
+dA
+rI
+WG
+tc
+QF
+HQ
+dX
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(22,1,1) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+bd
+bk
+Sn
+bh
+cg
+zq
+cn
+rf
+OD
+IQ
+jO
+wF
+OD
+zR
+cK
+bo
+db
+IZ
+ef
+DK
+dg
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+dh
+pL
+WU
+Uy
+dr
+mD
+di
+Zs
+OD
+IQ
+jO
+xj
+OD
+dA
+dA
+rI
+dS
+Sy
+LX
+QF
+dX
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(23,1,1) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Hq
+yo
+yo
+AW
+Sn
+cg
+zq
+cn
+uz
+CY
+oE
+XO
+ar
+MM
+lf
+cK
+bo
+db
+cx
+XD
+va
+va
+nJ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+XS
+va
+va
+Ik
+WU
+dr
+mD
+di
+oR
+CY
+oE
+XO
+ar
+MM
+dA
+dA
+rI
+dS
+wJ
+hB
+yo
+yo
+sB
+cB
+cB
+cB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(24,1,1) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Fk
+zg
+TE
+TE
+TE
+Ln
+Um
+cg
+MZ
+SN
+JG
+MM
+MM
+MM
+MM
+MM
+nK
+ls
+Nt
+db
+ph
+Nr
+Nr
+Nr
+Nr
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Nr
+Nr
+Nr
+Nr
+Si
+dr
+Nv
+Ku
+eR
+MM
+MM
+MM
+MM
+MM
+tu
+vd
+dP
+dS
+wq
+DB
+Ln
+MM
+MM
+DB
+TE
+TE
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(25,1,1) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Ie
+Gu
+zU
+nc
+qx
+Lz
+bk
+qb
+bk
+cG
+CG
+MM
+hB
+yo
+AW
+qE
+iU
+nz
+IZ
+DK
+TN
+Nr
+Nr
+Nr
+Nr
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Nr
+Nr
+Nr
+Nr
+pL
+CI
+pL
+Yn
+re
+MM
+hB
+yo
+AW
+qQ
+mN
+Wl
+Sy
+QF
+HQ
+oK
+MM
+KY
+MM
+vu
+MM
+MM
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(26,1,1) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Ie
+Gu
+zU
+LV
+qf
+Lz
+mT
+bk
+qb
+FE
+yG
+JT
+DB
+TE
+Ln
+rq
+QS
+DK
+uW
+IZ
+ef
+Nr
+Nr
+Nr
+Nr
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Nr
+Nr
+Nr
+Nr
+DR
+pL
+CI
+Qm
+JH
+oB
+DB
+TE
+Ln
+QE
+xx
+QF
+Qy
+Sy
+LX
+oK
+MM
+MM
+MM
+vu
+cB
+cB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(27,1,1) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+sW
+sA
+yo
+yo
+yo
+AW
+nn
+cg
+ik
+Ui
+dj
+MM
+MM
+MM
+MM
+MM
+pZ
+eS
+ct
+db
+uj
+Nr
+Nr
+Nr
+Nr
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Nr
+Nr
+Nr
+Nr
+OE
+dr
+dx
+OS
+qu
+MM
+MM
+MM
+MM
+MM
+jW
+yT
+BD
+dS
+cA
+hB
+yo
+AW
+MM
+hB
+cB
+cB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(28,1,1) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+xC
+TE
+TE
+Ln
+Sn
+cg
+zq
+cn
+uz
+ao
+Id
+iV
+gv
+MM
+lf
+cK
+bo
+db
+IZ
+UI
+am
+am
+bD
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Fy
+am
+am
+xV
+WU
+dr
+mD
+di
+oR
+ao
+pv
+iV
+gv
+MM
+uN
+dA
+rI
+dS
+Sy
+DB
+TE
+TE
+Bo
+cB
+cB
+cB
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+uA
+uA
+uA
+uA
+uA
+uA
+uA
+uA
+uA
+uA
+Br
+jP
+jP
+jP
+jP
+VP
+VP
+VP
+VP
+VP
+aa
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(29,1,1) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Cj
+Cj
+Cj
+Cj
+Cj
+Cj
+Cj
+Cj
+Cj
+Cj
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+bd
+hq
+qb
+bh
+cg
+zq
+cn
+Oy
+eA
+sr
+Pk
+dH
+eA
+qH
+cK
+bo
+db
+ef
+DK
+cx
+dg
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+dh
+LT
+CI
+Uy
+dr
+mD
+di
+os
+eA
+sr
+Pk
+jy
+eA
+ly
+dA
+rI
+dS
+LX
+QF
+wJ
+dX
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+uA
+uA
+Br
+Br
+Br
+Br
+Br
+Br
+Br
+Br
+Br
+jP
+dZ
+dZ
+jP
+VP
+VP
+VP
+VP
+VP
+aa
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(30,1,1) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Cj
+lc
+HN
+bV
+aC
+VS
+vP
+Wi
+ex
+Cj
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+bd
+nx
+bk
+cG
+cg
+zq
+cn
+cn
+NP
+jZ
+VO
+VO
+Wu
+JU
+cK
+bo
+lI
+SU
+IZ
+cF
+dg
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+dh
+Kg
+pL
+Yn
+dr
+mD
+di
+di
+NP
+jZ
+VO
+VO
+Wu
+FC
+dA
+rI
+um
+BH
+Sy
+tc
+dX
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+uA
+uA
+Br
+iQ
+Bi
+oh
+HT
+bH
+lx
+dn
+mJ
+jP
+rT
+sE
+jP
+VP
+VP
+VP
+VP
+VP
+aa
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(31,1,1) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+Cj
+Cj
+FX
+FX
+oN
+Cj
+Rd
+Wi
+hi
+aD
+aF
+fr
+Wi
+mo
+Cj
+Cj
+Cj
+rM
+AX
+AX
+AX
+AX
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+Rc
+Sn
+dl
+dl
+dl
+dl
+cn
+cn
+NP
+Ek
+VO
+VO
+MB
+JU
+yH
+Qh
+Qh
+RL
+pm
+IZ
+WD
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+HH
+WU
+dl
+dl
+dl
+dl
+Qh
+Qh
+NP
+sz
+VO
+VO
+Tv
+FC
+yH
+Qh
+Qh
+RL
+Pw
+Sy
+ac
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Br
+Br
+rB
+rB
+Iz
+Br
+PI
+dn
+mf
+bC
+vg
+bO
+dn
+Pd
+jP
+tk
+tk
+jP
+VP
+VP
+VP
+VP
+VP
+aa
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(32,1,1) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+Cj
+Ih
+CO
+Tw
+Tw
+iK
+xI
+Wi
+Wi
+Wi
+Wi
+bt
+Wi
+Wi
+Cj
+aV
+WF
+rM
+AX
+AX
+AX
+AX
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+bd
+zD
+dl
+vM
+dp
+dl
+dl
+cn
+NP
+Kv
+jc
+VO
+Sl
+zO
+Wf
+NT
+dQ
+Wf
+cz
+uW
+dg
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+dh
+hw
+dl
+Fw
+dp
+dl
+dl
+Qh
+du
+nv
+VO
+VO
+vC
+zO
+Wf
+NT
+dQ
+Wf
+Ol
+Qy
+dX
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Br
+Dq
+Kx
+ad
+ad
+PC
+lK
+dn
+dn
+dn
+dn
+dn
+dn
+dn
+Ce
+dn
+zB
+Fr
+Fr
+Fr
+Fr
+Fr
+Nq
+aa
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(33,1,1) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+Cj
+CR
+GD
+OB
+ak
+an
+bl
+fa
+Xe
+Cj
+Cj
+Oa
+Wi
+Wi
+Hc
+Wi
+Wi
+rM
+rM
+rM
+rM
+rM
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+bd
+bk
+ZP
+Bu
+NQ
+aR
+dl
+cn
+NP
+nN
+VO
+VO
+kw
+aT
+bT
+OR
+TW
+kZ
+IZ
+DK
+dg
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+dh
+pL
+dT
+NQ
+NQ
+dy
+dl
+Qh
+NP
+nN
+VO
+VO
+kw
+aT
+dJ
+TW
+TW
+Cr
+Sy
+QF
+dX
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Br
+ap
+Rn
+tg
+ae
+bm
+pS
+bq
+zB
+Br
+Br
+GO
+dn
+dn
+Nz
+dn
+dn
+Fr
+wz
+ca
+cj
+Ws
+Nq
+aa
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(34,1,1) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+ai
+aj
+Eo
+Tw
+Tw
+al
+bl
+KV
+Xe
+Cj
+Cj
+Oa
+Wi
+Wi
+Wi
+Wi
+Wi
+rM
+aY
+ot
+pX
+rM
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+bd
+cG
+NQ
+NQ
+NQ
+aW
+dl
+cn
+Da
+Ob
+jO
+Fq
+GX
+zz
+dK
+TW
+TW
+TW
+TN
+uW
+dg
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+dh
+Yn
+NQ
+NQ
+NQ
+dz
+dl
+Qh
+Da
+Ob
+jO
+Fq
+GX
+zz
+dK
+OR
+TW
+TW
+HQ
+Qy
+dX
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+bg
+Tm
+Vx
+ad
+ad
+af
+pS
+bq
+zB
+Br
+Br
+GO
+dn
+dn
+dn
+dn
+dn
+yP
+bY
+cb
+ml
+Fr
+Nq
+aa
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(35,1,1) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+Cj
+gH
+wZ
+tb
+cp
+ah
+vt
+KV
+Wi
+Wi
+Wi
+Wi
+Wi
+Wi
+Wi
+Wi
+Wi
+Wj
+ot
+vK
+ay
+rM
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+bd
+zs
+dl
+Ip
+xZ
+dl
+dl
+cn
+NP
+ny
+VO
+oT
+FC
+kb
+RL
+kS
+qI
+RL
+wc
+DK
+dg
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+dh
+Qc
+dl
+Ip
+xZ
+dl
+dl
+Qh
+NP
+ny
+VO
+ch
+FC
+kb
+YW
+kS
+qI
+RL
+dW
+QF
+dX
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Br
+uc
+EM
+dw
+qL
+Px
+PJ
+bq
+Nz
+dn
+dn
+dn
+dn
+dn
+dn
+dn
+nV
+Fr
+wz
+cc
+cl
+Fr
+Nq
+aa
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(36,1,1) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+Cj
+Tw
+Tw
+Tw
+Tw
+zQ
+KV
+Wi
+hi
+bs
+aK
+fr
+Wi
+Wi
+Wi
+Wi
+Wi
+rM
+aY
+NV
+aJ
+rM
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+bd
+cG
+dl
+dl
+dl
+dl
+cn
+cn
+NP
+Cm
+VO
+KH
+FC
+Qh
+kb
+Qh
+Qh
+Wf
+pm
+uW
+dg
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+dh
+Yn
+dl
+dl
+dl
+dl
+Qh
+Qh
+NP
+Cm
+VO
+KH
+FC
+Qh
+kb
+Qh
+Qh
+Wf
+Pw
+Qy
+dX
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Br
+ad
+ad
+ad
+ad
+Xu
+bq
+dn
+mf
+yB
+Hf
+bO
+dn
+dn
+dn
+dn
+zB
+Fr
+Fr
+Fr
+Fr
+Fr
+Nq
+aa
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(37,1,1) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+Cj
+cq
+Ad
+yK
+yK
+Cj
+uD
+Wi
+au
+ZY
+Xy
+aw
+Wi
+Wi
+bt
+Wi
+Xe
+rM
+rM
+rM
+rM
+rM
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+bd
+nx
+bk
+bk
+cg
+zq
+cn
+cn
+NN
+eA
+eA
+Wk
+NN
+cK
+cK
+bo
+Cd
+IZ
+TN
+cx
+dg
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+dh
+Kg
+pL
+pL
+dr
+mD
+di
+di
+NN
+eA
+eA
+Wk
+NN
+dA
+dA
+rI
+nt
+Sy
+HQ
+wJ
+dX
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Br
+FL
+jr
+ND
+ND
+Br
+vh
+dn
+IX
+Ql
+xK
+DJ
+dn
+dn
+dn
+dn
+dn
+Fr
+wz
+rm
+cj
+Fr
+Nq
+aa
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(38,1,1) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+pF
+pF
+pF
+pF
+pF
+Cj
+Cj
+Cj
+Cj
+Cj
+Cj
+Cj
+Cj
+us
+aU
+Wi
+df
+rM
+aY
+ot
+pX
+rM
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+bd
+Sn
+bh
+bk
+cg
+zq
+cn
+cn
+aa
+aa
+aa
+aa
+aa
+cK
+cK
+bo
+db
+ef
+qg
+DK
+hI
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NX
+dh
+WU
+Uy
+pL
+dr
+mD
+di
+di
+NN
+NN
+NN
+NN
+NN
+dA
+dA
+rI
+dS
+LX
+SX
+QF
+Nc
+LK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+pF
+pF
+pF
+Br
+Br
+Br
+Br
+Br
+Br
+Br
+Br
+Br
+Br
+xR
+bS
+dn
+Nz
+yP
+bY
+cb
+ml
+Fr
+Nq
+aa
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(39,1,1) = {"
+Jj
+Fj
+Fj
+VL
+Fj
+Fj
+Fc
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+aa
+aa
+aa
+aa
+Cj
+Cj
+Cj
+Cj
+ai
+Cj
+Cj
+Cj
+us
+Vg
+Wi
+Wi
+Wj
+ot
+vK
+ay
+rM
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+zA
+sA
+sA
+sA
+sA
+sA
+nA
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+zA
+sA
+sA
+sA
+sA
+sA
+nA
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+zA
+sA
+sA
+sA
+sA
+sA
+nA
+aa
+aa
+NN
+NN
+NN
+NN
+NN
+aa
+aa
+zA
+sA
+sA
+sA
+sA
+sA
+nA
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+uA
+uA
+Br
+Br
+Br
+Br
+Br
+Br
+Br
+Br
+xR
+qF
+dn
+dn
+Fr
+wz
+cc
+cl
+Fr
+Nq
+aa
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(40,1,1) = {"
+Jj
+Fj
+FQ
+xp
+ol
+Fj
+Fc
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+aa
+Cj
+HN
+HN
+Ei
+bz
+aH
+Hm
+Wi
+Wi
+Wi
+Wi
+Wi
+rM
+aY
+NV
+aJ
+rM
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NN
+NN
+NN
+NN
+NN
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+uA
+uA
+Br
+Bi
+Bi
+oh
+pd
+hg
+lx
+dn
+dn
+dn
+dn
+zB
+Fr
+Fr
+Fr
+Fr
+Fr
+Nq
+aa
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(41,1,1) = {"
+Jj
+Fj
+FQ
+xp
+zv
+Fj
+Fc
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+aa
+Cj
+MG
+MG
+hi
+aG
+GA
+fr
+Wi
+Wi
+Wi
+Wi
+Xe
+rM
+rM
+rM
+rM
+rM
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+NN
+NN
+NN
+NN
+NN
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Br
+bu
+bu
+mf
+bF
+uC
+bO
+dn
+dn
+dn
+dn
+dn
+Fr
+wz
+ca
+cj
+Fr
+Nq
+aa
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(42,1,1) = {"
+Jj
+Fj
+Ft
+xp
+ol
+Fj
+Fc
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+aa
+Cj
+Wi
+bt
+Wi
+Wi
+Wi
+Wi
+Wi
+Wi
+Wi
+Wi
+Wi
+rM
+aY
+ot
+pX
+rM
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Br
+GO
+dn
+dn
+Nz
+dn
+dn
+dn
+dn
+dn
+dn
+dn
+yP
+bY
+cb
+ml
+Fr
+Nq
+aa
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(43,1,1) = {"
+Jj
+Fj
+FQ
+xp
+ol
+Fj
+Pj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+aa
+Cj
+ek
+Wi
+Zp
+Cj
+Cj
+Oa
+Wi
+Wi
+Wi
+Wi
+Wi
+Wj
+ot
+vK
+ay
+rM
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+nQ
+nQ
+nQ
+nQ
+nQ
+nQ
+aa
+aa
+Br
+JL
+dn
+zB
+Br
+Br
+GO
+dn
+dn
+dn
+dn
+nV
+Fr
+cS
+cd
+cl
+Fr
+Nq
+aa
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(44,1,1) = {"
+Jj
+Fj
+FQ
+xp
+xp
+QL
+Pj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+aa
+Cj
+ek
+Wi
+Xe
+Cj
+Cj
+Oa
+Wi
+Wi
+Wi
+Wi
+df
+rM
+rK
+ot
+aJ
+rM
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+nQ
+cs
+VO
+ul
+oy
+nQ
+aa
+aa
+Br
+JX
+dn
+zB
+Br
+Br
+GO
+dn
+dn
+dn
+dn
+zB
+Fr
+Fr
+Fr
+Fr
+Fr
+Nq
+aa
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(45,1,1) = {"
+Jj
+Fj
+FQ
+xp
+ol
+Fj
+Pj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+aa
+Cj
+Wi
+Wi
+Wi
+Wi
+Wi
+Wi
+Wi
+Wi
+Wi
+Wi
+Xe
+rM
+rM
+rM
+rM
+rM
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+nQ
+vn
+VO
+qj
+VO
+nQ
+aa
+aa
+Br
+GO
+dn
+dn
+dn
+dn
+dn
+dn
+Nz
+dn
+dn
+dn
+Fr
+IW
+ca
+cj
+Fr
+Nq
+aa
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(46,1,1) = {"
+Jj
+Fj
+Ft
+xp
+ol
+Fj
+Fc
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Bs
+Jj
+Jj
+Wm
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+aa
+Cj
+Oa
+Wi
+hi
+bz
+aM
+fr
+Wi
+bt
+Wi
+Wi
+Wi
+rM
+aY
+ot
+pX
+rM
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+nQ
+AH
+VO
+Uv
+VO
+nQ
+aa
+aa
+Br
+Nz
+dn
+mf
+pd
+bL
+bO
+dn
+dn
+dn
+dn
+dn
+yP
+bY
+cb
+ml
+Fr
+Nq
+aa
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(47,1,1) = {"
+Jj
+Fj
+FQ
+xp
+zv
+Fj
+Fc
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+aa
+Cj
+Wi
+Wi
+uB
+Ta
+aN
+aw
+aS
+aS
+Wi
+Wi
+Wi
+Wj
+ot
+vK
+ay
+rM
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+nQ
+AL
+VO
+tA
+lE
+nQ
+aa
+aa
+Br
+dn
+dn
+IX
+bG
+bM
+DJ
+Bc
+Bc
+dn
+dn
+dn
+Fr
+cS
+cd
+cl
+Fr
+Nq
+aa
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(48,1,1) = {"
+Jj
+Fj
+FQ
+xp
+ol
+Fj
+Fc
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+aa
+Cj
+Cj
+Cj
+Cj
+Cj
+Cj
+Cj
+Cj
+Cj
+Cj
+Cj
+Cj
+rM
+rK
+ot
+aJ
+rM
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+nQ
+nQ
+nQ
+nQ
+nQ
+nQ
+aa
+aa
+Br
+Br
+Br
+Br
+Br
+Br
+Br
+Br
+Br
+Br
+Br
+Br
+Fr
+Fr
+Fr
+Fr
+Fr
+Nq
+aa
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(49,1,1) = {"
+Jj
+Fj
+Fj
+BU
+Fj
+Fj
+Fc
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+aa
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+rM
+rM
+rM
+rM
+rM
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+(50,1,1) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+"}
+
 (1,1,2) = {"
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJjJj
-JjsJsJsJsJsJsJsJsJsJsJsJsJsJsJsJsJsJsJsJsJsJsJsJsJsJsJsJsJsJsJsJsJsJsJsJsJsJsJsJsJsJsJsJsJsJsJsJsJJj
-JjsJsJsJsJsJRjRjYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzsJsJsJsJsJJj
-JjsJsJsJsJsJRjRjYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzYzsJsJsJsJsJJj
-JjsJxmxmxmxmxmxmxmxmxmxmxmxmxmxmxmxmxmxmxmxmxmxmxmxmxmxmxmxmxmxmxmxmxmxmxmxmxmxmxmxmxmxmxmsJsJsJsJJj
-JjsJhfVdVdVdVdVdVdVdVdVdVdVdVdVdVdVdVdVdVdVdVdVdVdVdVdVdVdVdVdVdVdVdVdVdVdVdVdVdVdVdVdVdvbsJsJsJsJJj
-JjsJFiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiMPsJsJsJsJJj
-JjsJFiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiMPsJsJsJsJJj
-JjsJFiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiMPsJsJsJsJJj
-JjGvjskmkmkmkmkmOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCkmkmkmkmkmSgGvGvsJsJJj
-JjsJFiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiMPsJsJsJsJJj
-JjsJFiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiMPsJsJsJsJJj
-JjsJFiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiMPsJsJsJsJJj
-JjGvNfkmkmkmkmkmkmkmkmkmkmkmkmkmkmkmkmkmkmkmkmkmkmkmkmkmkmkmkmkmkmkmkmkmkmkmkmkmkmkmkmkmWHGvGvGvGvJj
-JjsJFiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiMPsJsJsJsJJj
-JjsJFiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiMPsJsJsJsJJj
-JjwCFiTiTiTiTiZzTiTiTiTiTiTiTiTiTiTiTiTiTiSZSZSZSZSZSZSZSZTiTiTiTiTiTiTiTiTiTiTiTiTiTiTiMPwCwCwCsJJj
-JjhcrJkmkmkmkmYJOCOCOCOCOCOCOCOCOCOCOCOCOCmLysysystRysysmLOCOCOCOCOCOCOCOCOCOCkmkmkmkmkmWHnPhchcsJJj
-JjRjRjRjRjRjRjRjRjRjRjTiTiTiTiTiTiTiTiTiTiSZMgdNBKRIAjDTSZTiTiTiTiTiTiTiTiTiTiRjRjRjRjRjRjRjRjRjRjJj
-JjRjRjRjRjRjRjRjRjRjRjSZSZSZSZSZSZSZSZSZNwSZXkEnEnEnEnjqwUSZSZSZSZSZSZSZSZSZSZRjRjRjRjRjRjRjRjRjRjJj
-JjRjRjRjRjRjRjRjRjRjBIIwCuCuHaCuCuCuCuCuCuCuuiEnEnEnEnuOCuCuCuCuCuCuCuQNCuIwCuBIRjRjRjRjRjRjRjRjRjJj
-JjRjRjRjRjRjRjRjRjRjBIUDhkEnynpepepepepepepepeWLFfFfAkpepepepepepepepeenHSUDhkBIRjRjRjRjRjRjRjRjRjJj
-JjRjRjRjRjRjRjRjRjRjBIYUzVEnynpepepepepepepepeEnEnEnEnpepepepepepepepeenEnYezVBIRjRjRjRjRjRjRjRjRjJj
-JjRjRjRjRjRjRjRjRjRjBIRrdREnynEnEnEnEnEnEnEnEnEnEnEnEnEnEnEnEnEnEnEnEnenEnRrdRBIRjRjRjRjRjRjRjRjRjJj
-JjaqaqaqaqaqaqaqaqNZbbiSiSbbbbbbbbbbbbbbbbbbbbbbluTxggggggggggggggagagagagezezagaqaqaqaqaqaqaqaqaqJj
-JjaqaqaqaqaqaqaqaqNZUYUYUYUYehwAmudLipipiprgelIVaPaPggbwJcbwJcbwrMaqaqaqaqaqaqaqaqaqaqaqaqaqaqaqaqJj
-JjaqaqaqaqaqaqaqaqNZUYpVpVsYLtdtdtdtdtDXLtdtdtrZaPaPvHbwbwQBbwbwrMaqaqaqaqaqaqaqaqaqaqaqaqaqaqaqaqJj
-JjaqaqaqaqaqaqaqaqNZUYpVpVaXiBdtdtdtdtiBdtdtdteuaPswvHbwbwbwbwbwDfaqaqaqaqaqaqaqaqaqaqaqaqaqaqaqaqJj
-JjaqaqaqaqaqaqaqUYUYUYUYUYrMrMDfrMrMDfrMdtoDGgIVzGaPNObwbwbwbwbwrMaqaqaqaqaqaqaqaqaqaqaqaqaqaqaqaqJj
-JjaqaqaqaqaqaqaqUYRljhcCRlrMmavkrMZobwrMdtoDGnUYaPaPggbwIcbwIcbwrMaqaqaqaqaqaqaqaqaqaqaqaqaqaqaqaqJj
-JjaqaqaqaqaqaqaqUYxoavaveprMsgbwrMeyWarMVTfvGgUYeNaPggggfUggggggggAiaqaqaqaqaqaqaqaqaqaqaqaqaqaqaqJj
-JjaqaqaqaqaqaqaqUYjhavOUjhrMPVbwrMeytIrMdtoDGnUYaPaPkRaPaPaPeJeKeKAiaqaqaqaqaqaqaqaqaqaqaqaqaqaqaqJj
-JjaqaqaqaqaqaqaqUYjhavavjhrMpIbwDfHLWarMdtoDGgUYcuaPzlaPOLaPeJeKeKAiaqaqaqaqaqaqaqaqaqaqaqaqaqaqaqJj
-JjaqrMrMrMrMrMrMggrMhjrZUYUYUYUYUYKOKOKOKOKOKOKOeNaPrMrMrMrMrMrMrMrMrMrMrMrMrMrMrMrMrMrMrMrMrMaqaqJj
-aaaqrMPgPgPzPgCXggrMlaWiWiOaePOaugKOKOIfrAYtKOKOaPXzrMpwaYrMrMaJZJotrMaJGootrMaJGopXrMaJGopXrMaqaqJj
-aaaqrMAazIRizICcggrMWiWiWiWiWiWiWiKOEVXXTPXXEVKOaPaPrMerotcJrMNoEufbrMNoEufbrMLDvKfcrMLDvKfcrMaqaqJj
-aaaqrMOQUVPggwZbggrMOYWihihiWiWiNAKOXXTtuLnqXXKOaPaPrMpwotrMrMEuotpXrMEuotpXrMVZotEurMVZotEurMaqaqaa
-aaaqgggguaEdbcrCggrMHcfibBaIrjWiWiKOXXXXXHXXXXKOUPXzrMrMAArMrMrMAAferMrMAArMrMrMAArMrMrMAArMggAXAXAX
-aaaqhOGRfzaPswrvaPaPWifimQufrjWiWiKOskTrXXZMjoKOaPaPWiWiWiWiOaTuWiWiOaTuWiTuOaTuWiWiOaWiWiggggggrMrM
-aaaqddbxaPaPaPAVJRoSWifibKfjrjWiugKOKOKOZmKOKOKOaPaPfqWibtWiWiWiWiWiWibtWiWiWiWibtWiWiWiugggQkmiyErM
-aaaqggggyJlwlwrCggrMlaWiekBqWibtWiOaVROaWiOaWiCjaPXzCjHNMGWiftftWiWiWiCjCjHNMGWiftftWiWiWibNCqKhyErM
-aaaqrMxMPgXCPgPgggrMWiWiCjCjWiWiWiWiWiWiWiWiWiWiaPaPCjHNMGWiftBeWiWiWiCjCjHNMGWiBeftWiWiWibNyEyEkYrM
-aaaqrMbrPgHEPgCcggrMlaWiekJyWiWiWihihiWiWiWiWifqaPaPCjbVhiugCjCjlihiauCjCjbVhiugCjCjlihiauggcrcNZBrM
-aaaqrMBTPgDyPgPgggrMHcfibBaIfkCjtyeWaIrjWiWiugCjaPXzCjaCaDWioQfwWibsZYCjCjbzfxWioQfwWibzRkggggggDfrM
-aaaqrMrMrMrMrMrMggrMWiwvmQufekCjekmQufrjNACjCjCjaPaPCjVSaFWifwfwWiaKXyCjCjaHQuWifwfwWiaMaNggyEyEyErM
-aaaqaqaqaqaqaqaqaqCjWifibKfjfkCjtybKfjrjWiWifyCjcuaPCjvPfrWiWiWiWifrawCjCjvPfrWiWibtWifrawggyEyEyErM
-aaaqaqaqaqaqaqaqaqCjlaWifrfrWiWiWifrfrWiWiWifACjaPXzCjfBfBWifCkGWiWiWiCjCjfEWiWifCfCWiWifEggyEyEyErM
-aaaqaqaqaqaqaqaqaqCjaxqOWiWiXefGXeWiWiWiXeWifHCjfIaPCjWiWifJfKfKekWiWiCjCjWiWiekWiWiQjWiWiggyEyEyErM
-aaaqaqaqaqaqaqaqaqCjCjCjfNfNaiCjaifNfNCjCjCjCjCjfOfPCjCjCjCjfNfNCjCjCjCjCjCjCjCjfNfNCjCjCjggrMrMrMrM
-aaaqaqaqaqaqaqaqaqaqaqWpfRfRThvNfRfRfRcEThGhcEfSxexefTfRcEfRfRfRThcEfRfRcEfRzWSrmwmwaqaqaqaqaqaqaqaa
-aaaqaqaqaqaqaqaqaqaqaqfQfRfRfRfRfRfRfRfRfRfRfRfVxexefVfRfRfRfRfRfRfRfRfRfRfRmwmwmwmwaqaqaqaqaqaqaqaa
-aaaaaaaaaaaaaaaaaaaaaaaafWfWfWfWfWfWfWfWfWfWfWfWxexefWfWfWfWfWfWfWfWfWfWfWfWaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaafXfXfXfXfXfXfXfXfXfXfXfXxexefXfXfXfXfXfXfXfXfXfXfXfXaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaafYfYfYfYfYfYfYfYfYfYfYfZxexefZfYfYfYfYfYfYfYfYfYfYfYaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaxexexexexexexexexexexexexexexexexexexexexexexexexexeaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaQOQOgbgbgbgbgbgbgbgbgbgbgbgbgbgbgbgbgbgbgbgbgbgbQOQOaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaVcVcVcVcgcgcgcgcgcgcgcgcgdgdgcgcgcgcgcgcgcgcgcgcVcVcaaaaaaaaaaaaaaaaaaaaaapF
-aaaaaaaaaaaaaaaaaaaaaaaagdgdgdgdgdgdgdgdgdgdgdgdgdgdgdgdgdgdgdgdgdgdgdgdgdgdaaaaaaaaaaaaaaaaaaaaaapF
-aaaaaaaaaaaaaaaaaaaaaaaagegegegegegegegegegegcgdgdgdgdgcgegegegegegegegegegeaaaaaaaaaaaaaaaaaaaaaayS
-aaaaaaaaaaaaaaaaaaaaaaaagegeDzgegegegegegegegcgdgdgdgdgcgegegeqRgegeqRDzgegeaaaaaaaaaaaaaaaaaaaaaayS
-aaaaaaaaaaaaaaaaaaaaaaaagegebibibibibibigegegcgcgigigcgcgegebibibibibibigegeaaaaaaaaaaaaaaaaaaaaaapF
-aaaaaaaaaaaaaaaaaaaaaaaagegebimcbebemcbivzgegegegegegegegepqbimcbebemcbigegeaaaaaaaaaaaaaaaaaaaaaapF
-aaaaaaaaaaaaaaaaaaaaaaaagegebibebebebebigegegegegegegegegegebibebebebebigegeaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaagcgcbiMWbebeSfbigcgcgcgcgegegcgcgcgcbiSfbebeMWbigcgcaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaLcgibibitXbebibigigigigcgegegcgigigibibitXbebibiLcgiaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaagiLcgiSRoJoJSRgigigifMgcgegegcfMgigigiSRoJoJSRgigiLcaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaqaqagjgjCyCygjgjgjgjglgkgegegkglgjgjgjgjCyCygjgjqaqaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaFRqWgjgjCyCyCyCyCyCyCyCyCyCyCyCyCyCyCyCyCyCygjgjFRqWaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaqaqaqWXjCyCyCyCyCyCyCyCyCyCyCyCyCyCyCyCyCyCygjqWXjqaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaqWFRXjgjCyCyCyCyCyCyCyCyCyCyCyCyCyCyCyCyCyCyFRXjgjFRaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaFRgjgjgjCyCygjgjgjgjglgkgmgmgkglgjgjgjgjCyCygjgjFRgjaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaajCKIgnSOdVdVSOvRgngnfDgogmgmgofDgngnvRSOdVdVSOgnjCKIaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaagnjCdDdDFWQQdDdDgngngngogmgmgogngngndDdDFWQQdDdDgnjCaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaagogodDsKQQQQsKdDgogogogogmgmgogogogodDsKQQQQsKdDgogoaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaagmgmdDBRdDdDRgdDgmgmgmgmgmgmgmgmgmgmdDBRdDdDRgdDgmgmaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaagmgmuPQQQQQQQQQDgmgmgmgmgmgmgmgmgmgmQDQQQQQQQQuPgmgmaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaagmgmuPuPuPuPuPuPgmgmgogogngngogogmgmuPuPuPuPuPuPgmgmaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaagmgmgmgmgmgmgmgmgmgmgogpgpgpgpgogmgmgmgmgmgmgmgmgmgmaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaagmgmgmgmgmgmgmgmgmgmgogpgpgpgpgogmgmgmgmgmgmgmgmgmgmaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaagpgpgpgpgpgpgpgpgpgpgpgpgpgpgpgpgpgpgpgpgpgpgpgpgpgpaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaVjVjVjVjVjVjVjVjVjVjVjVjgqgqVjVjVjVjVjVjVjVjVjVjVjVjaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaagrgrgrgrgrgrgrgrgrgrgrgrgqgqgrgrgrgrgrgrgrgrgrgrgrgraaaaaaaaaaaaaaaaaaaaaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcUhaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcxwaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcciaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaZcZcZcZcZcZcZcZcZcZcgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxZcZcZcZcZcZcZcZcZcZcaaaa
-aaaaaaaaaaaaaaaaaaaaaaaagAgAgAgAgAgAgAgAgAgAgAgAgBgBgAgAgAgAgAgAgAgAgAgAgAgAaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaDWDWDWDWDWDWDWDWDWDWDWDWgBgBDWDWDWDWDWDWDWDWDWDWDWDWaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaagDgDgDgDgDgDgDgDgDgDgDgDgDgDgDgDgDgDgDgDgDgDgDgDgDgDaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaagEgEgEgEgEgEgEgEgEgEgCgDgDgDgDgCgEgEgEgEgEgEgEgEgEgEaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaagEgEgEgEgEgEgElhgEgEgCgDgDgDgDgCgEgElhgEgEgEgEgEgEgEaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaagEgEuPuPuPuPuPuPgEgEgCgCAcAcgCgCgEgEuPuPuPuPuPuPgEgEaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaagEgEuPQQQQQQQQuPgEgEgEgEgEgEgEgEgEgEuPQQQQQQQQuPgEgEaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaagEgEdDQQdDdDQQdDgEgEgEgEgEgEgEgEgEgEdDQQdDdDQQdDgEgEaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaagkgkdDlNQQQQrpdDgkgkgkgkgEgEgkgkgkAPdDrpQQQQPidDgkgkaaaaECECaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaFRgjdDdDzKQQdDdDOwgjgjgkgEgEgkgjgjgjdDdDzKQQdDdDFRgjaaaaLWheaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaagjFRgjQaCyCyQagjgjgjglgkgEgEgkglgjgjgjQaCyCyQagjgjFRaaaaFZsxaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaqaqagjgjCyCygjgjgjgjglgkgEgEgkglgjgjgjgjCyCygjgjqaqaaaaaheheaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaFRqWgjgjCyCyCyCyCyCyCyCyCyCyCyCyCyCyCyCyCyCygjgjFRqWIKMVFZsxaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaqaqaqWXjCyCyCyCyCyCyCyCyCyigCyCyCyCyCyCyCyCygjqWXjqaIKUnheheaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaqWFRXjgjCyCyCyCyCyCyCyCyCyCyCyCyCyCyCyCyCyCyFRXjgjFRaaIyaaIyaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaFRgjgjgjCyCygjgjgjgjglgkgGgGgkglgjgjgjgjCyCygjgjFRgjaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaqaFRgjvWCyCyvWjzgjgjglgkgGgGgkglgjgjjzvWCyCyvWgjqaFRaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaagjqadldldTNQdldlgjgjgjgkgGgGgkgjgjgjdldldTNQdldlgjqaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaagkDddlnwNQNQnwdlIRgkgkgkgGgGgkgkgkgkdlnwNQNQnwdlEIgkaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaagGgGdlNQNQNQNQdlgGgGgGgGgGgGgGgGgGgGdlNQNQNQNQdlgGgGaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaagGgGdlSYNQNQSYdlgGgGgGgGrsgGgGgGgGgGdlSYNQNQSYdlgGgGaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaagGgGdldldldldldlgGgGgJgJCgCggJgJgGgGdldldldldldlgGgGaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaagGgGgGvUgGgGvUgGgGgGgJgLgLgLgLgJgGgGgGvUgGgGvUgGgGgGaaaaaaaanmaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaagGgGgGgGgGgGgGgGgGgGgJgLgLgLgLgJgGgGgGgGgGgGgGgGgGgGaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaagLgLgLgLgLgLgLgLgLgLgLgLgLgLgLgLgLgLgLgLgLgLgLgLgLgLaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaabRbRbRgJgJgJgJgJgJgJgJgJgLgLgJgJgJgJgJgJgJgJgJgJgJgJaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaGfGfgMgMgMgMgMgMgMgMgMgMgMgMgMgMgMgMgMgMgMgMgMgMGfGfaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaVPVPVPVPVPVPVPVPgNgNgNgNgNgNgNgNgNgNgNgNgNgNgNgNgNgNgNgNgNgNgNgNgNgNVPVPVPVPVPVPVPVPaaaaaaaa
-aaaaaaaaVPVPVPVPVPVPVPVPgOgOgOgOgOgOgOgOgOgOgOgPgNgNgPgOgOgOgOgOgOgOgOgOgOgOVPVPVPVPVPVPVPVPaaaaaaaa
-aaaaaaaaVPVPVPVPVPVPVPVPgQgQgQgQgQgQgQgQgQgQgQgQgNgNgQgQgQgQgQgQgQgQgQgQgQgQVPVPVPVPVPVPVPVPaaaaaaaa
-aaaaaaaaVPVPVPVPVPVPVPVPgSgSgSgSgSgSgSgSgSgSgSgSgNgNgSgSgSgSgSgSgSgSgSgSgSgSVPVPVPVPVPVPVPVPaaheaaaa
-aaVPVPVPVPVPVPVPVPVPVPgTgRgRgRgRgRgRgRgRgRgRgRozgNgNozgRgRgRgRgRgRgRgRgRgRgRDDDDDDDDVPVPVPCbCbCbCbaa
-aaVPVPVPVPVPVPVPVPVPVPUjNJgRgRoVgRgRgRgRgRNJoVgWgNgNgXoVNJgRgRgRgRyRgRgRgRNJtjDDDDDDVPVPVPVPCbCbCbaa
-aaVPVPVPVPVPVPVPVPBrBrBrBrgYgYBrBrOtOtOtOtOtOtOtgZhajPBrBrBrgYgYbgBrBrBrBrBrBrBrgYgYBrBrBryFNWxfNbjP
-aaVPVPVPVPjPBCBCyFBraLaLmZdndndnbnOtOtNMByzJOtOthltkjPBibuhnhohoJLmZBcBrBrBibuhnJLJLJLvQXYyFvrghCCjP
-aaVPVPVPVPjPwRwRyFBrTjdndndnhphpdnOtQRkKrakKLEOtXntkjPBibudnhthtdndnBcBrbgBibuhodndnhofoRDIFtktkOXjP
-aaVPVPVPVPjPwRwRyFBreYdnmfmfdndndnOtkKoGBMcDkKOttkrFjPohmfdnhxhxdnmfIXBrBrChmfdndndndnJLjjyFLizMzMyF
-aaVPVPVPVPjPQbWqyFBrCehysnYlhAdntNOtkKkKCQAMkKOttkZIjPHTbCdnnVdnNzyBQlbgBrpdhCdnnVdndndndntktktktkjP
-aaVPVPVPVPjPwRwRyFbgdnhyhzGHhAdndnOtqtkKkKZQXAOtcLtkjPbHvgtNBrBrCeHfxKBrBrhgEltNBrBrdnNzdnlVtkOptkjP
-aaVPjPjPjPjPFTwRyFKmCehyAUaEhAdntNOtOtOtxSOtOtOttktkjPlxbOdndndndnbODJBrbglxbOdndndndndntNjPtkOptkjP
-aaVPjPYdklqmpCwRhZbqdndnbONIdnNzdndndnGOdnGOdnBrtkrFjPdndndndndndndndnbgBrdndndndndndndndntktktkJmjP
-aaVPjPgfXxcOwRpChZnDdndnBrBrdndndndndndndndndndntktkjPdndndndndndndndnBrBrdndnNzdndndndndnyFRCwjwjGT
-aaVPjPeLaBSVwRpChZnDdndnmffLdndndnmfmfdndndndnjAtktktkdndnNzdndndndndnGOGOdndndndndndndndnyFtktkOXjP
-aaVPjPxdXxjPjDwRyFKmCehysnYlrdBrINsnYlhANzdntNBrXntkCsdndndndnzBdnnVDshLdndnDshMdnnVzBdndnyFtktktkjP
-aaVPjPcYTejPwRwRyFbgeYhyhzGHhABrhyhzGHhAtNBrBrBrVEtkjPPydnPyFrFryPFrFrFryPFrFrFryPFrFrFryPjPyFYywRjP
-aaVPjPdMkljPQbWqyFBrCehyAUaErdBrINAUhQhAdndnhRBrtktkFrFryPFrFrwzbYTkFrwzbYTkFrwzbYTkFrwzPtTkdGKUKUpF
-aaVPabQtQtjPwRwRyFBrdndnbObOdndndnbObOdndndnhSBrtktkFrurTkhUFrhVprcdFrhVcbJdFrhVcbcdFrhVcbcddGKUKUpF
-aaVPVPVPVPjPjPjPyFBrTjdnzBdndnnVzBdndndnzBdnhWBrXntkFrurbWbZFrcjOJclFrcjOJclFrcjOJclFrcjOJcldGKUKUpF
-aaVPVPVPVPVPVPVPFrFrhNJeFrFrWwWwWwWwWwWwWwWwWwWwJmrFFrFrFrFrFrFrFrFrFrFrFrFrFrFrFrFrFrFrFrFrdGKUKUpF
-aaVPVPVPVPVPVPVPFrBblLlLBbFrTOuSkqYDioioioazicMqtktkJKidieiejPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPabKUKUpF
-aaVPVPVPVPVPVPVPFrZFYOlLGsFrLsLspbLsLsifLsLsLsUftktkrkidieiejPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPabababpF
-aaVPVPVPVPVPVPVPFrBblLlLBbFrLsLsLsLshPLsLshPLshJtktkjPjPjPjPjPabVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPaa
-aaVPVPVPVPVPVPVPFrZVBbBbZVFrLsvAihFrFrFPFrFrFPwVtkrFabVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPaa
-aaVPVPVPVPVPVPVPFrFrFrFrFrFruKvAsmFrViItFrItItFrXntkabVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPvEeiVPaa
-aaVPVPVPVPVPVPVPVPNqWwiAiAiipbvAihFrCBItFriuivFrtkJmabVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPeoVPaa
-aaVPVPVPVPVPVPVPVPNqWwiAiAiiLsvAsmFrViHjFriuivFrtktkabVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPaa
-aaVPVPVPVPVPVPVPabWwWwWwWwWwuKvAihFrKkItFPCAivFrXnrFabVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPVPaa
-aaiEVPVPVPVPVPVPabWwWwbUbUWwWwWwWwFrFrFrFrFrFrFrleklabababababababababababzczcabVPVPVPVPVPVPVPVPVPaa
-aaNHNHNHNHNHNHNHNHNHngUKininzdininininininininininininininininininininUeinUKinngNHNHNHNHNHNHNHNHNHee
-aaNHNHNHNHNHNHNHNHNHnginininzdUMUMUMUMUMUMUMUMininininUMUMUMUMUMUMUMUMUeinGdedngNHNHNHNHNHNHNHNHNHee
-aaNHNHNHNHNHNHNHNHNHngRKBOinzdUMUMUMUMUMUMUMUMecrxrxTdUMUMUMUMUMUMUMUMUeQWRKBOngNHNHNHNHNHNHNHNHNHee
-aaNHNHNHNHNHNHNHNHNHngPqPqPqCWPqPqPqPqPqPqPqyfininininilPqPqPqPqPqPqPqdUPqPqPqngNHNHNHNHNHNHNHNHNHee
-aaNHNHNHNHNHNHNHNHNHNHQxQxQxQxQxQxQxQxQxHwQxXlcfcfcfcfQUdaQxQxQxQxQxQxQxQxQxQxNHNHNHNHNHNHNHNHNHNHee
-aaNHNHNHNHNHNHNHNHNHNHiaiaiaiaiaiaiaiaiaiaQxhdibeByqIPryQxiaiaiaiaiaiaiaiaiaiaNHNHNHNHNHNHNHNHNHNHee
-aaiaixiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaQxwhQxOHQxEmQxQxiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiavYiaiaee
-aaiaixiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiavYiaiaee
-aazTYEiriririririririririririririririririririririrRziriririririririririririririririririririrxtuXiaNH
-aaiaixiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiavYiaiaNH
-aaiaixiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiavYiaiaee
-aaiaixiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiavYiaiaee
-aairJbiririririririririririririririririririririririririririririririririririririririririririrDwiriree
-aaiaixiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiavYiaiaNH
-aaiaixiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiavYiaiaNH
-aaiaixiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiaiavYiaiaNH
-aairJbiririririririririririririririririririririririririririririririririririririririririririrDwirirNH
-aaiaaZsNsNsNsNsNsNsNsNsNsNsNsNsNsNsNsNsNsNsNsNsNsNsNsNsNsNsNsNsNsNsNsNsNsNsNsNsNsNsNsNsNsNsNOKiaiaNH
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(2,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+sJ
+sJ
+sJ
+sJ
+sJ
+sJ
+sJ
+Gv
+sJ
+sJ
+sJ
+Gv
+sJ
+sJ
+wC
+hc
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+iE
+NH
+NH
+NH
+NH
+NH
+NH
+ia
+ia
+zT
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+"}
+(3,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+sJ
+sJ
+xm
+hf
+Fi
+Fi
+Fi
+js
+Fi
+Fi
+Fi
+Nf
+Fi
+Fi
+Fi
+rJ
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+rM
+rM
+rM
+rM
+gg
+hO
+dd
+gg
+rM
+rM
+rM
+rM
+aq
+aq
+aq
+aq
+aq
+aq
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+jP
+jP
+jP
+jP
+jP
+jP
+jP
+ab
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+NH
+NH
+NH
+NH
+NH
+NH
+ix
+ix
+YE
+ix
+ix
+ix
+Jb
+ix
+ix
+ix
+Jb
+aZ
+"}
+(4,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+sJ
+sJ
+xm
+Vd
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+km
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+rM
+Pg
+Aa
+OQ
+gg
+GR
+bx
+gg
+xM
+br
+BT
+rM
+aq
+aq
+aq
+aq
+aq
+aq
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+jP
+Yd
+gf
+eL
+xd
+cY
+dM
+Qt
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+NH
+NH
+NH
+NH
+NH
+NH
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(5,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+sJ
+sJ
+xm
+Vd
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+km
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+rM
+Pg
+zI
+UV
+ua
+fz
+aP
+yJ
+Pg
+Pg
+Pg
+rM
+aq
+aq
+aq
+aq
+aq
+aq
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+jP
+kl
+Xx
+aB
+Xx
+Te
+kl
+Qt
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+NH
+NH
+NH
+NH
+NH
+NH
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(6,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+sJ
+sJ
+xm
+Vd
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+km
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+rM
+Pz
+Ri
+Pg
+Ed
+aP
+aP
+lw
+XC
+HE
+Dy
+rM
+aq
+aq
+aq
+aq
+aq
+aq
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+jP
+jP
+jP
+jP
+jP
+jP
+qm
+cO
+SV
+jP
+jP
+jP
+jP
+jP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+NH
+NH
+NH
+NH
+NH
+NH
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(7,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Rj
+Rj
+xm
+Vd
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+km
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+rM
+Pg
+zI
+gw
+bc
+sw
+aP
+lw
+Pg
+Pg
+Pg
+rM
+aq
+aq
+aq
+aq
+aq
+aq
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+BC
+wR
+wR
+Qb
+wR
+FT
+pC
+wR
+wR
+jD
+wR
+Qb
+wR
+jP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+NH
+NH
+NH
+NH
+NH
+NH
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(8,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Rj
+Rj
+xm
+Vd
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Zz
+YJ
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+rM
+CX
+Cc
+Zb
+rC
+rv
+AV
+rC
+Pg
+Cc
+Pg
+rM
+aq
+aq
+aq
+aq
+aq
+aq
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+BC
+wR
+wR
+Wq
+wR
+wR
+wR
+pC
+pC
+wR
+wR
+Wq
+wR
+jP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+NH
+NH
+NH
+NH
+NH
+NH
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(9,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+OC
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+OC
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+aq
+aq
+aq
+aq
+UY
+UY
+UY
+UY
+UY
+gg
+gg
+gg
+gg
+gg
+aP
+JR
+gg
+gg
+gg
+gg
+gg
+aq
+aq
+aq
+aq
+aq
+aq
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+yF
+yF
+yF
+yF
+yF
+yF
+hZ
+hZ
+hZ
+yF
+yF
+yF
+yF
+yF
+Fr
+Fr
+Fr
+Fr
+Fr
+Fr
+VP
+VP
+ab
+ab
+NH
+NH
+NH
+NH
+NH
+NH
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(10,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+OC
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+OC
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+NZ
+NZ
+NZ
+NZ
+UY
+Rl
+xo
+jh
+jh
+rM
+rM
+rM
+rM
+rM
+aP
+oS
+rM
+rM
+rM
+rM
+rM
+Cj
+Cj
+Cj
+Cj
+aq
+aq
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+VP
+VP
+VP
+VP
+VP
+Br
+Br
+Br
+Br
+Br
+bg
+Km
+bq
+nD
+nD
+Km
+bg
+Br
+Br
+Br
+Fr
+Bb
+ZF
+Bb
+ZV
+Fr
+Nq
+Nq
+Ww
+Ww
+NH
+NH
+NH
+NH
+NH
+NH
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(11,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+OC
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+OC
+Rj
+Rj
+BI
+BI
+BI
+BI
+bb
+UY
+UY
+UY
+UY
+jh
+av
+av
+av
+hj
+la
+Wi
+OY
+Hc
+Wi
+Wi
+la
+Wi
+la
+Hc
+Wi
+Wi
+la
+ax
+Cj
+aq
+aq
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+VP
+VP
+VP
+VP
+VP
+Br
+aL
+Tj
+eY
+Ce
+dn
+Ce
+dn
+dn
+dn
+Ce
+eY
+Ce
+dn
+Tj
+hN
+lL
+YO
+lL
+Bb
+Fr
+Ww
+Ww
+Ww
+Ww
+ng
+ng
+ng
+ng
+NH
+NH
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(12,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+OC
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+OC
+Ti
+SZ
+Iw
+UD
+YU
+Rr
+iS
+UY
+pV
+pV
+UY
+cC
+av
+OU
+av
+rZ
+Wi
+Wi
+Wi
+fi
+fi
+fi
+Wi
+Wi
+Wi
+fi
+wv
+fi
+Wi
+qO
+Cj
+Wp
+fQ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+VP
+VP
+VP
+gT
+Uj
+Br
+aL
+dn
+dn
+hy
+hy
+hy
+dn
+dn
+dn
+hy
+hy
+hy
+dn
+dn
+Je
+lL
+lL
+lL
+Bb
+Fr
+iA
+iA
+Ww
+bU
+UK
+in
+RK
+Pq
+Qx
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(13,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+OC
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+OC
+Ti
+SZ
+Cu
+hk
+zV
+dR
+iS
+UY
+pV
+pV
+UY
+Rl
+ep
+jh
+jh
+UY
+Wi
+Wi
+hi
+bB
+mQ
+bK
+ek
+Cj
+ek
+bB
+mQ
+bK
+fr
+Wi
+fN
+fR
+fR
+fW
+fX
+fY
+xe
+QO
+Vc
+gd
+ge
+ge
+ge
+ge
+ge
+gc
+Lc
+gi
+qa
+FR
+qa
+qW
+FR
+jC
+gn
+go
+gm
+gm
+gm
+gm
+gm
+gp
+Vj
+gr
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gA
+DW
+gD
+gE
+gE
+gE
+gE
+gE
+gk
+FR
+gj
+qa
+FR
+qa
+qW
+FR
+qa
+gj
+gk
+gG
+gG
+gG
+gG
+gG
+gL
+bR
+Gf
+gN
+gO
+gQ
+gS
+gR
+NJ
+Br
+mZ
+dn
+mf
+sn
+hz
+AU
+bO
+Br
+mf
+sn
+hz
+AU
+bO
+zB
+Fr
+Bb
+Gs
+Bb
+ZV
+Fr
+iA
+iA
+Ww
+bU
+in
+in
+BO
+Pq
+Qx
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(14,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+OC
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+OC
+Ti
+SZ
+Cu
+En
+En
+En
+bb
+UY
+sY
+aX
+rM
+rM
+rM
+rM
+rM
+UY
+Oa
+Wi
+hi
+aI
+uf
+fj
+Bq
+Cj
+Jy
+aI
+uf
+fj
+fr
+Wi
+fN
+fR
+fR
+fW
+fX
+fY
+xe
+QO
+Vc
+gd
+ge
+ge
+ge
+ge
+ge
+gc
+gi
+Lc
+qa
+qW
+qa
+FR
+gj
+KI
+jC
+go
+gm
+gm
+gm
+gm
+gm
+gp
+Vj
+gr
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gA
+DW
+gD
+gE
+gE
+gE
+gE
+gE
+gk
+gj
+FR
+qa
+qW
+qa
+FR
+gj
+FR
+qa
+Dd
+gG
+gG
+gG
+gG
+gG
+gL
+bR
+Gf
+gN
+gO
+gQ
+gS
+gR
+gR
+gY
+dn
+dn
+mf
+Yl
+GH
+aE
+NI
+Br
+fL
+Yl
+GH
+aE
+bO
+dn
+Fr
+Fr
+Fr
+Fr
+Fr
+Fr
+ii
+ii
+Ww
+Ww
+in
+in
+in
+Pq
+Qx
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(15,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+OC
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+OC
+Ti
+SZ
+Ha
+yn
+yn
+yn
+bb
+eh
+Lt
+iB
+rM
+ma
+sg
+PV
+pI
+UY
+eP
+Wi
+Wi
+rj
+rj
+rj
+Wi
+Wi
+Wi
+fk
+ek
+fk
+Wi
+Xe
+ai
+Th
+fR
+fW
+fX
+fY
+xe
+gb
+Vc
+gd
+ge
+Dz
+bi
+bi
+bi
+bi
+bi
+gi
+gj
+gj
+qW
+Xj
+gj
+gn
+dD
+dD
+dD
+uP
+uP
+gm
+gm
+gp
+Vj
+gr
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gA
+DW
+gD
+gE
+gE
+uP
+uP
+dD
+dD
+dD
+gj
+gj
+gj
+qW
+Xj
+gj
+gj
+dl
+dl
+dl
+dl
+dl
+gG
+gG
+gL
+bR
+gM
+gN
+gO
+gQ
+gS
+gR
+gR
+gY
+dn
+hp
+dn
+hA
+hA
+hA
+dn
+dn
+dn
+rd
+hA
+rd
+dn
+dn
+Ww
+TO
+Ls
+Ls
+Ls
+uK
+pb
+Ls
+uK
+Ww
+zd
+zd
+zd
+CW
+Qx
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(16,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+OC
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+OC
+Ti
+SZ
+Cu
+pe
+pe
+En
+bb
+wA
+dt
+dt
+Df
+vk
+bw
+bw
+bw
+UY
+Oa
+Wi
+Wi
+Wi
+Wi
+Wi
+bt
+Wi
+Wi
+Cj
+Cj
+Cj
+Wi
+fG
+Cj
+vN
+fR
+fW
+fX
+fY
+xe
+gb
+Vc
+gd
+ge
+ge
+bi
+mc
+be
+MW
+bi
+SR
+gj
+gj
+Xj
+gj
+gj
+SO
+dD
+sK
+BR
+QQ
+uP
+gm
+gm
+gp
+Vj
+gr
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gA
+DW
+gD
+gE
+gE
+uP
+QQ
+QQ
+lN
+dD
+Qa
+gj
+gj
+Xj
+gj
+gj
+vW
+dl
+nw
+NQ
+SY
+dl
+vU
+gG
+gL
+gJ
+gM
+gN
+gO
+gQ
+gS
+gR
+oV
+Br
+dn
+hp
+dn
+dn
+dn
+dn
+Nz
+dn
+dn
+Br
+Br
+Br
+dn
+nV
+Ww
+uS
+Ls
+Ls
+vA
+vA
+vA
+vA
+vA
+Ww
+in
+UM
+UM
+Pq
+Qx
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(17,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+OC
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+OC
+Ti
+SZ
+Cu
+pe
+pe
+En
+bb
+mu
+dt
+dt
+rM
+rM
+rM
+rM
+Df
+UY
+ug
+Wi
+NA
+Wi
+Wi
+ug
+Wi
+Wi
+Wi
+ty
+ek
+ty
+Wi
+Xe
+ai
+fR
+fR
+fW
+fX
+fY
+xe
+gb
+gc
+gd
+ge
+ge
+bi
+be
+be
+be
+tX
+oJ
+Cy
+Cy
+Cy
+Cy
+Cy
+dV
+FW
+QQ
+dD
+QQ
+uP
+gm
+gm
+gp
+Vj
+gr
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gA
+DW
+gD
+gE
+gE
+uP
+QQ
+dD
+QQ
+zK
+Cy
+Cy
+Cy
+Cy
+Cy
+Cy
+Cy
+dT
+NQ
+NQ
+NQ
+dl
+gG
+gG
+gL
+gJ
+gM
+gN
+gO
+gQ
+gS
+gR
+gR
+Br
+bn
+dn
+dn
+tN
+dn
+tN
+dn
+dn
+dn
+IN
+hy
+IN
+dn
+zB
+Ww
+kq
+pb
+Ls
+ih
+sm
+ih
+sm
+ih
+Ww
+in
+UM
+UM
+Pq
+Qx
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(18,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+OC
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+OC
+Ti
+SZ
+Cu
+pe
+pe
+En
+bb
+dL
+dt
+dt
+rM
+Zo
+ey
+ey
+HL
+KO
+KO
+KO
+KO
+KO
+KO
+KO
+Oa
+Wi
+hi
+eW
+mQ
+bK
+fr
+Wi
+fN
+fR
+fR
+fW
+fX
+fY
+xe
+gb
+gc
+gd
+ge
+ge
+bi
+be
+be
+be
+be
+oJ
+Cy
+Cy
+Cy
+Cy
+Cy
+dV
+QQ
+QQ
+dD
+QQ
+uP
+gm
+gm
+gp
+Vj
+gr
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gA
+DW
+gD
+gE
+gE
+uP
+QQ
+dD
+QQ
+QQ
+Cy
+Cy
+Cy
+Cy
+Cy
+Cy
+Cy
+NQ
+NQ
+NQ
+NQ
+dl
+gG
+gG
+gL
+gJ
+gM
+gN
+gO
+gQ
+gS
+gR
+gR
+Ot
+Ot
+Ot
+Ot
+Ot
+Ot
+Ot
+dn
+dn
+mf
+sn
+hz
+AU
+bO
+dn
+Ww
+YD
+Ls
+Ls
+Fr
+Fr
+Fr
+Fr
+Fr
+Fr
+in
+UM
+UM
+Pq
+Qx
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(19,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+OC
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+OC
+Ti
+SZ
+Cu
+pe
+pe
+En
+bb
+ip
+dt
+dt
+Df
+bw
+Wa
+tI
+Wa
+KO
+KO
+EV
+XX
+XX
+sk
+KO
+VR
+Wi
+hi
+aI
+uf
+fj
+fr
+Wi
+fN
+fR
+fR
+fW
+fX
+fY
+xe
+gb
+gc
+gd
+ge
+ge
+bi
+mc
+be
+Sf
+bi
+SR
+gj
+Cy
+Cy
+Cy
+gj
+SO
+dD
+sK
+Rg
+QQ
+uP
+gm
+gm
+gp
+Vj
+gr
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gA
+DW
+gD
+gE
+gE
+uP
+QQ
+QQ
+rp
+dD
+Qa
+gj
+Cy
+Cy
+Cy
+gj
+vW
+dl
+nw
+NQ
+SY
+dl
+vU
+gG
+gL
+gJ
+gM
+gN
+gO
+gQ
+gS
+gR
+gR
+Ot
+Ot
+QR
+kK
+kK
+qt
+Ot
+dn
+dn
+mf
+Yl
+GH
+hQ
+bO
+dn
+Ww
+io
+Ls
+hP
+Fr
+Vi
+CB
+Vi
+Kk
+Fr
+in
+UM
+UM
+Pq
+Qx
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(20,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+OC
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+OC
+Ti
+SZ
+Cu
+pe
+pe
+En
+bb
+ip
+DX
+iB
+rM
+rM
+rM
+rM
+rM
+KO
+If
+XX
+Tt
+XX
+Tr
+KO
+Oa
+Wi
+Wi
+rj
+rj
+rj
+Wi
+Wi
+Cj
+cE
+fR
+fW
+fX
+fY
+xe
+gb
+gc
+gd
+ge
+ge
+bi
+bi
+bi
+bi
+bi
+gi
+gj
+Cy
+Cy
+Cy
+gj
+vR
+dD
+dD
+dD
+QD
+uP
+gm
+gm
+gp
+Vj
+gr
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gA
+DW
+gD
+gE
+lh
+uP
+uP
+dD
+dD
+dD
+gj
+gj
+Cy
+Cy
+Cy
+gj
+jz
+dl
+dl
+dl
+dl
+dl
+gG
+gG
+gL
+gJ
+gM
+gN
+gO
+gQ
+gS
+gR
+gR
+Ot
+NM
+kK
+oG
+kK
+kK
+Ot
+GO
+dn
+dn
+hA
+hA
+hA
+dn
+dn
+Ww
+io
+if
+Ls
+FP
+It
+It
+Hj
+It
+Fr
+in
+UM
+UM
+Pq
+Qx
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(21,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+OC
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+OC
+Ti
+Nw
+Cu
+pe
+pe
+En
+bb
+ip
+Lt
+dt
+dt
+dt
+VT
+dt
+dt
+KO
+rA
+TP
+uL
+XH
+XX
+Zm
+Wi
+Wi
+Wi
+Wi
+NA
+Wi
+Wi
+Xe
+Cj
+Th
+fR
+fW
+fX
+fY
+xe
+gb
+gc
+gd
+ge
+ge
+ge
+vz
+ge
+gc
+gi
+gi
+gj
+Cy
+Cy
+Cy
+gj
+gn
+gn
+go
+gm
+gm
+gm
+gm
+gm
+gp
+Vj
+gr
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gA
+DW
+gD
+gE
+gE
+gE
+gE
+gE
+gk
+Ow
+gj
+gj
+Cy
+Cy
+Cy
+gj
+gj
+gj
+IR
+gG
+gG
+gG
+gG
+gG
+gL
+gJ
+gM
+gN
+gO
+gQ
+gS
+gR
+gR
+Ot
+By
+ra
+BM
+CQ
+kK
+xS
+dn
+dn
+dn
+Nz
+tN
+dn
+dn
+zB
+Ww
+io
+Ls
+Ls
+Fr
+Fr
+Fr
+Fr
+FP
+Fr
+in
+UM
+UM
+Pq
+Hw
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(22,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+OC
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+SZ
+mL
+SZ
+SZ
+Cu
+pe
+pe
+En
+bb
+rg
+dt
+dt
+oD
+oD
+fv
+oD
+oD
+KO
+Yt
+XX
+nq
+XX
+ZM
+KO
+Oa
+Wi
+Wi
+Wi
+Cj
+Wi
+Wi
+Wi
+Cj
+Gh
+fR
+fW
+fX
+fY
+xe
+gb
+gc
+gd
+ge
+ge
+ge
+ge
+ge
+gc
+gi
+gi
+gj
+Cy
+Cy
+Cy
+gj
+gn
+gn
+go
+gm
+gm
+gm
+gm
+gm
+gp
+Vj
+gr
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gA
+DW
+gD
+gE
+gE
+gE
+gE
+gE
+gk
+gj
+gj
+gj
+Cy
+Cy
+Cy
+gj
+gj
+gj
+gk
+gG
+gG
+gG
+gG
+gG
+gL
+gJ
+gM
+gN
+gO
+gQ
+gS
+gR
+NJ
+Ot
+zJ
+kK
+cD
+AM
+ZQ
+Ot
+GO
+dn
+dn
+dn
+Br
+dn
+dn
+dn
+Ww
+az
+Ls
+hP
+Fr
+It
+iu
+iu
+CA
+Fr
+in
+UM
+UM
+Pq
+Qx
+Qx
+Qx
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(23,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+OC
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+SZ
+ys
+Mg
+Xk
+ui
+pe
+pe
+En
+bb
+el
+dt
+dt
+Gg
+Gn
+Gg
+Gn
+Gg
+KO
+KO
+EV
+XX
+XX
+jo
+KO
+Wi
+Wi
+Wi
+ug
+Cj
+fy
+fA
+fH
+Cj
+cE
+fR
+fW
+fX
+fY
+xe
+gb
+gc
+gd
+gc
+gc
+gc
+ge
+ge
+gc
+gi
+fM
+gl
+Cy
+Cy
+Cy
+gl
+fD
+gn
+go
+gm
+gm
+go
+go
+go
+gp
+Vj
+gr
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gA
+DW
+gD
+gC
+gC
+gC
+gE
+gE
+gk
+gj
+gl
+gl
+Cy
+Cy
+Cy
+gl
+gl
+gj
+gk
+gG
+gG
+gJ
+gJ
+gJ
+gL
+gJ
+gM
+gN
+gO
+gQ
+gS
+gR
+oV
+Ot
+Ot
+LE
+kK
+kK
+XA
+Ot
+dn
+dn
+dn
+tN
+Br
+hR
+hS
+hW
+Ww
+ic
+Ls
+Ls
+FP
+It
+iv
+iv
+iv
+Fr
+in
+UM
+UM
+yf
+Xl
+hd
+wh
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(24,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+OC
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+SZ
+ys
+dN
+En
+En
+WL
+En
+En
+bb
+IV
+rZ
+eu
+IV
+UY
+UY
+UY
+UY
+KO
+KO
+KO
+KO
+KO
+KO
+KO
+Cj
+Wi
+fq
+Cj
+Cj
+Cj
+Cj
+Cj
+Cj
+fS
+fV
+fW
+fX
+fZ
+xe
+gb
+gc
+gd
+gd
+gd
+gc
+ge
+ge
+gc
+gc
+gc
+gk
+Cy
+Cy
+Cy
+gk
+go
+go
+go
+gm
+gm
+go
+gp
+gp
+gp
+Vj
+gr
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gA
+DW
+gD
+gD
+gD
+gC
+gE
+gE
+gk
+gk
+gk
+gk
+Cy
+Cy
+Cy
+gk
+gk
+gk
+gk
+gG
+gG
+gJ
+gL
+gL
+gL
+gJ
+gM
+gN
+gP
+gQ
+gS
+oz
+gW
+Ot
+Ot
+Ot
+Ot
+Ot
+Ot
+Ot
+Br
+dn
+jA
+Br
+Br
+Br
+Br
+Br
+Ww
+Mq
+Uf
+hJ
+wV
+Fr
+Fr
+Fr
+Fr
+Fr
+in
+in
+ec
+in
+cf
+ib
+Qx
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(25,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+OC
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+SZ
+ys
+BK
+En
+En
+Ff
+En
+En
+lu
+aP
+aP
+aP
+zG
+aP
+eN
+aP
+cu
+eN
+aP
+aP
+aP
+UP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+cu
+aP
+fI
+fO
+xe
+xe
+xe
+xe
+xe
+xe
+gb
+gd
+gd
+gd
+gd
+gi
+ge
+ge
+ge
+ge
+ge
+ge
+Cy
+Cy
+Cy
+gm
+gm
+gm
+gm
+gm
+gm
+gn
+gp
+gp
+gp
+gq
+gq
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gB
+gB
+gD
+gD
+gD
+Ac
+gE
+gE
+gE
+gE
+gE
+gE
+Cy
+Cy
+Cy
+gG
+gG
+gG
+gG
+gG
+rs
+Cg
+gL
+gL
+gL
+gL
+gM
+gN
+gN
+gN
+gN
+gN
+gN
+gZ
+hl
+Xn
+tk
+tk
+cL
+tk
+tk
+tk
+tk
+Xn
+VE
+tk
+tk
+Xn
+Jm
+tk
+tk
+tk
+tk
+Xn
+tk
+tk
+Xn
+le
+in
+in
+rx
+in
+cf
+eB
+OH
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(26,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+OC
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+SZ
+tR
+RI
+En
+En
+Ff
+En
+En
+Tx
+aP
+aP
+sw
+aP
+aP
+aP
+aP
+aP
+aP
+Xz
+aP
+aP
+Xz
+aP
+aP
+Xz
+aP
+aP
+Xz
+aP
+aP
+Xz
+aP
+fP
+xe
+xe
+xe
+xe
+xe
+xe
+gb
+gd
+gd
+gd
+gd
+gi
+ge
+ge
+ge
+ge
+ge
+ge
+Cy
+Cy
+Cy
+gm
+gm
+gm
+gm
+gm
+gm
+gn
+gp
+gp
+gp
+gq
+gq
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gB
+gB
+gD
+gD
+gD
+Ac
+gE
+gE
+gE
+gE
+gE
+gE
+Cy
+ig
+Cy
+gG
+gG
+gG
+gG
+gG
+gG
+Cg
+gL
+gL
+gL
+gL
+gM
+gN
+gN
+gN
+gN
+gN
+gN
+ha
+tk
+tk
+rF
+ZI
+tk
+tk
+rF
+tk
+tk
+tk
+tk
+tk
+tk
+tk
+rF
+tk
+tk
+tk
+rF
+tk
+Jm
+tk
+rF
+kl
+in
+in
+rx
+in
+cf
+yq
+Qx
+ia
+Rz
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(27,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+OC
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+SZ
+ys
+Aj
+En
+En
+Ak
+En
+En
+gg
+gg
+vH
+vH
+NO
+gg
+gg
+kR
+zl
+rM
+rM
+rM
+rM
+rM
+Wi
+fq
+Cj
+Cj
+Cj
+Cj
+Cj
+Cj
+Cj
+Cj
+Cj
+fT
+fV
+fW
+fX
+fZ
+xe
+gb
+gc
+gd
+gd
+gd
+gc
+ge
+ge
+gc
+gc
+gc
+gk
+Cy
+Cy
+Cy
+gk
+go
+go
+go
+gm
+gm
+go
+gp
+gp
+gp
+Vj
+gr
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gA
+DW
+gD
+gD
+gD
+gC
+gE
+gE
+gk
+gk
+gk
+gk
+Cy
+Cy
+Cy
+gk
+gk
+gk
+gk
+gG
+gG
+gJ
+gL
+gL
+gL
+gJ
+gM
+gN
+gP
+gQ
+gS
+oz
+gX
+jP
+jP
+jP
+jP
+jP
+jP
+jP
+jP
+jP
+tk
+Cs
+jP
+Fr
+Fr
+Fr
+Fr
+JK
+rk
+jP
+ab
+ab
+ab
+ab
+ab
+ab
+in
+in
+Td
+in
+cf
+IP
+Em
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(28,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+OC
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+SZ
+ys
+DT
+jq
+uO
+pe
+pe
+En
+gg
+bw
+bw
+bw
+bw
+bw
+gg
+aP
+aP
+rM
+pw
+er
+pw
+rM
+Wi
+Wi
+HN
+HN
+bV
+aC
+VS
+vP
+fB
+Wi
+Cj
+fR
+fR
+fW
+fX
+fY
+xe
+gb
+gc
+gd
+gc
+gc
+gc
+ge
+ge
+gc
+gi
+fM
+gl
+Cy
+Cy
+Cy
+gl
+fD
+gn
+go
+gm
+gm
+go
+go
+go
+gp
+Vj
+gr
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gA
+DW
+gD
+gC
+gC
+gC
+gE
+gE
+gk
+gj
+gl
+gl
+Cy
+Cy
+Cy
+gl
+gl
+gj
+gk
+gG
+gG
+gJ
+gJ
+gJ
+gL
+gJ
+gM
+gN
+gO
+gQ
+gS
+gR
+oV
+Br
+Bi
+Bi
+oh
+HT
+bH
+lx
+dn
+dn
+dn
+dn
+Py
+Fr
+ur
+ur
+Fr
+id
+id
+jP
+VP
+VP
+VP
+VP
+VP
+ab
+in
+UM
+UM
+il
+QU
+ry
+Qx
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(29,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+OC
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+SZ
+mL
+SZ
+wU
+Cu
+pe
+pe
+En
+gg
+Jc
+bw
+bw
+bw
+Ic
+fU
+aP
+OL
+rM
+aY
+ot
+ot
+AA
+Wi
+bt
+MG
+MG
+hi
+aD
+aF
+fr
+fB
+Wi
+Cj
+cE
+fR
+fW
+fX
+fY
+xe
+gb
+gc
+gd
+ge
+ge
+ge
+ge
+ge
+gc
+gi
+gi
+gj
+Cy
+Cy
+Cy
+gj
+gn
+gn
+go
+gm
+gm
+gm
+gm
+gm
+gp
+Vj
+gr
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gA
+DW
+gD
+gE
+gE
+gE
+gE
+gE
+gk
+gj
+gj
+gj
+Cy
+Cy
+Cy
+gj
+gj
+gj
+gk
+gG
+gG
+gG
+gG
+gG
+gL
+gJ
+gM
+gN
+gO
+gQ
+gS
+gR
+NJ
+Br
+bu
+bu
+mf
+bC
+vg
+bO
+dn
+dn
+dn
+dn
+dn
+yP
+Tk
+bW
+Fr
+ie
+ie
+jP
+VP
+VP
+VP
+VP
+VP
+ab
+in
+UM
+UM
+Pq
+da
+Qx
+Qx
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(30,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+OC
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+OC
+Ti
+SZ
+Cu
+pe
+pe
+En
+gg
+bw
+QB
+bw
+bw
+bw
+gg
+aP
+aP
+rM
+rM
+cJ
+rM
+rM
+Wi
+Wi
+Wi
+Wi
+ug
+Wi
+Wi
+Wi
+Wi
+fJ
+Cj
+fR
+fR
+fW
+fX
+fY
+xe
+gb
+gc
+gd
+ge
+ge
+ge
+pq
+ge
+gc
+gi
+gi
+gj
+Cy
+Cy
+Cy
+gj
+gn
+gn
+go
+gm
+gm
+gm
+gm
+gm
+gp
+Vj
+gr
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gA
+DW
+gD
+gE
+gE
+gE
+gE
+gE
+AP
+gj
+gj
+gj
+Cy
+Cy
+Cy
+gj
+gj
+gj
+gk
+gG
+gG
+gG
+gG
+gG
+gL
+gJ
+gM
+gN
+gO
+gQ
+gS
+gR
+gR
+Br
+hn
+dn
+dn
+dn
+tN
+dn
+dn
+dn
+Nz
+dn
+Py
+Fr
+hU
+bZ
+Fr
+ie
+ie
+jP
+VP
+VP
+VP
+VP
+VP
+ab
+in
+UM
+UM
+Pq
+Qx
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(31,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+OC
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+OC
+Ti
+SZ
+Cu
+pe
+pe
+En
+gg
+Jc
+bw
+bw
+bw
+Ic
+gg
+eJ
+eJ
+rM
+rM
+rM
+rM
+rM
+Oa
+Wi
+ft
+ft
+Cj
+oQ
+fw
+Wi
+fC
+fK
+fN
+fR
+fR
+fW
+fX
+fY
+xe
+gb
+gc
+gd
+ge
+ge
+bi
+bi
+bi
+bi
+bi
+gi
+gj
+Cy
+Cy
+Cy
+gj
+vR
+dD
+dD
+dD
+QD
+uP
+gm
+gm
+gp
+Vj
+gr
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gA
+DW
+gD
+gE
+lh
+uP
+uP
+dD
+dD
+dD
+gj
+gj
+Cy
+Cy
+Cy
+gj
+jz
+dl
+dl
+dl
+dl
+dl
+gG
+gG
+gL
+gJ
+gM
+gN
+gO
+gQ
+gS
+gR
+gR
+gY
+ho
+ht
+hx
+nV
+Br
+dn
+dn
+dn
+dn
+dn
+Fr
+Fr
+Fr
+Fr
+Fr
+jP
+jP
+jP
+VP
+VP
+VP
+VP
+VP
+ab
+in
+UM
+UM
+Pq
+Qx
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(32,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+OC
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+OC
+Ti
+SZ
+Cu
+pe
+pe
+En
+gg
+bw
+bw
+bw
+bw
+bw
+gg
+eK
+eK
+rM
+aJ
+No
+Eu
+rM
+Tu
+Wi
+ft
+Be
+Cj
+fw
+fw
+Wi
+kG
+fK
+fN
+fR
+fR
+fW
+fX
+fY
+xe
+gb
+gc
+gd
+ge
+qR
+bi
+mc
+be
+Sf
+bi
+SR
+gj
+Cy
+Cy
+Cy
+gj
+SO
+dD
+sK
+BR
+QQ
+uP
+gm
+gm
+gp
+Vj
+gr
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gA
+DW
+gD
+gE
+gE
+uP
+QQ
+QQ
+rp
+dD
+Qa
+gj
+Cy
+Cy
+Cy
+gj
+vW
+dl
+nw
+NQ
+SY
+dl
+vU
+gG
+gL
+gJ
+gM
+gN
+gO
+gQ
+gS
+gR
+gR
+gY
+ho
+ht
+hx
+dn
+Br
+dn
+dn
+dn
+dn
+zB
+Fr
+wz
+hV
+cj
+Fr
+VP
+VP
+ab
+VP
+VP
+VP
+VP
+VP
+ab
+in
+UM
+UM
+Pq
+Qx
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(33,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+OC
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+OC
+Ti
+SZ
+Cu
+pe
+pe
+En
+gg
+rM
+rM
+Df
+rM
+rM
+gg
+eK
+eK
+rM
+ZJ
+Eu
+ot
+AA
+Wi
+Wi
+Wi
+Wi
+li
+Wi
+Wi
+Wi
+Wi
+ek
+Cj
+Th
+fR
+fW
+fX
+fY
+xe
+gb
+gc
+gd
+ge
+ge
+bi
+be
+be
+be
+tX
+oJ
+Cy
+Cy
+Cy
+Cy
+Cy
+dV
+FW
+QQ
+dD
+QQ
+uP
+gm
+gm
+gp
+Vj
+gr
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gA
+DW
+gD
+gE
+gE
+uP
+QQ
+dD
+QQ
+zK
+Cy
+Cy
+Cy
+Cy
+Cy
+Cy
+Cy
+dT
+NQ
+NQ
+NQ
+dl
+gG
+gG
+gL
+gJ
+gM
+gN
+gO
+gQ
+gS
+gR
+gR
+bg
+JL
+dn
+dn
+Nz
+Ce
+dn
+dn
+dn
+dn
+dn
+yP
+bY
+pr
+OJ
+Fr
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+ab
+in
+UM
+UM
+Pq
+Qx
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(34,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+OC
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+OC
+Ti
+SZ
+Cu
+pe
+pe
+En
+ag
+aq
+aq
+aq
+aq
+aq
+Ai
+Ai
+Ai
+rM
+ot
+fb
+pX
+fe
+Wi
+Wi
+Wi
+Wi
+hi
+bs
+aK
+fr
+Wi
+Wi
+Cj
+cE
+fR
+fW
+fX
+fY
+xe
+gb
+gc
+gd
+ge
+ge
+bi
+be
+be
+be
+be
+oJ
+Cy
+Cy
+Cy
+Cy
+Cy
+dV
+QQ
+QQ
+dD
+QQ
+uP
+gm
+gm
+gp
+Vj
+gr
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gA
+DW
+gD
+gE
+gE
+uP
+QQ
+dD
+QQ
+QQ
+Cy
+Cy
+Cy
+Cy
+Cy
+Cy
+Cy
+NQ
+NQ
+NQ
+NQ
+dl
+gG
+gG
+gL
+gJ
+gM
+gN
+gO
+gQ
+gS
+gR
+yR
+Br
+mZ
+dn
+mf
+yB
+Hf
+bO
+dn
+dn
+dn
+nV
+Fr
+Tk
+cd
+cl
+Fr
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+ab
+in
+UM
+UM
+Pq
+Qx
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(35,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+OC
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+OC
+Ti
+SZ
+Cu
+pe
+pe
+En
+ag
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+rM
+rM
+rM
+rM
+rM
+Oa
+Wi
+Wi
+Wi
+au
+ZY
+Xy
+aw
+Wi
+Wi
+Cj
+fR
+fR
+fW
+fX
+fY
+xe
+gb
+gc
+gd
+ge
+qR
+bi
+mc
+be
+MW
+bi
+SR
+gj
+gj
+gj
+FR
+gj
+SO
+dD
+sK
+Rg
+QQ
+uP
+gm
+gm
+gp
+Vj
+gr
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gA
+DW
+gD
+gE
+gE
+uP
+QQ
+QQ
+Pi
+dD
+Qa
+gj
+gj
+gj
+FR
+gj
+vW
+dl
+nw
+NQ
+SY
+dl
+vU
+gG
+gL
+gJ
+gM
+gN
+gO
+gQ
+gS
+gR
+gR
+Br
+Bc
+Bc
+IX
+Ql
+xK
+DJ
+dn
+dn
+dn
+Ds
+Fr
+Fr
+Fr
+Fr
+Fr
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+ab
+in
+UM
+UM
+Pq
+Qx
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(36,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+OC
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+OC
+Ti
+SZ
+QN
+en
+en
+en
+ag
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+rM
+aJ
+No
+Eu
+rM
+Tu
+bt
+Cj
+Cj
+Cj
+Cj
+Cj
+Cj
+Cj
+Cj
+Cj
+fR
+fR
+fW
+fX
+fY
+xe
+gb
+gc
+gd
+ge
+Dz
+bi
+bi
+bi
+bi
+bi
+gi
+gj
+gj
+qW
+Xj
+gj
+gn
+dD
+dD
+dD
+uP
+uP
+gm
+gm
+gp
+Vj
+gr
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gA
+DW
+gD
+gE
+gE
+uP
+uP
+dD
+dD
+dD
+gj
+gj
+gj
+qW
+Xj
+gj
+gj
+dl
+dl
+dl
+dl
+dl
+gG
+gG
+gL
+gJ
+gM
+gN
+gO
+gQ
+gS
+gR
+gR
+Br
+Br
+Br
+Br
+bg
+Br
+Br
+bg
+Br
+GO
+hL
+Fr
+wz
+hV
+cj
+Fr
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+ab
+Ue
+Ue
+Ue
+dU
+Qx
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(37,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+OC
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+OC
+Ti
+SZ
+Cu
+HS
+En
+En
+ag
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+rM
+Go
+Eu
+ot
+AA
+Wi
+Wi
+Cj
+Cj
+Cj
+Cj
+Cj
+Cj
+Cj
+Cj
+Cj
+cE
+fR
+fW
+fX
+fY
+xe
+QO
+Vc
+gd
+ge
+ge
+ge
+ge
+ge
+gc
+Lc
+gi
+qa
+FR
+Xj
+gj
+FR
+jC
+gn
+go
+gm
+gm
+gm
+gm
+gm
+gp
+Vj
+gr
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gA
+DW
+gD
+gE
+gE
+gE
+gE
+gE
+gk
+FR
+gj
+qa
+FR
+Xj
+gj
+FR
+qa
+gj
+EI
+gG
+gG
+gG
+gG
+gG
+gL
+gJ
+Gf
+gN
+gO
+gQ
+gS
+gR
+gR
+Br
+Br
+bg
+Br
+Br
+Br
+bg
+Br
+Br
+GO
+dn
+yP
+bY
+cb
+OJ
+Fr
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+ab
+in
+in
+QW
+Pq
+Qx
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(38,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+OC
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+OC
+Ti
+SZ
+Iw
+UD
+Ye
+Rr
+ez
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+rM
+ot
+fb
+pX
+rM
+Tu
+Wi
+HN
+HN
+bV
+bz
+aH
+vP
+fE
+Wi
+Cj
+fR
+fR
+fW
+fX
+fY
+xe
+QO
+Vc
+gd
+ge
+ge
+ge
+ge
+ge
+gc
+gi
+Lc
+qa
+qW
+qa
+FR
+gj
+KI
+jC
+go
+gm
+gm
+gm
+gm
+gm
+gp
+Vj
+gr
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gx
+gA
+DW
+gD
+gE
+gE
+gE
+gE
+gE
+gk
+gj
+FR
+qa
+qW
+qa
+FR
+gj
+FR
+qa
+gk
+gG
+gG
+gG
+gG
+gG
+gL
+gJ
+Gf
+gN
+gO
+gQ
+gS
+gR
+NJ
+Br
+Bi
+Bi
+Ch
+pd
+hg
+lx
+dn
+dn
+dn
+dn
+Fr
+Tk
+Jd
+cl
+Fr
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+zc
+UK
+Gd
+RK
+Pq
+Qx
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(39,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+OC
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+OC
+Ti
+SZ
+Cu
+hk
+zV
+dR
+ez
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+rM
+rM
+rM
+rM
+rM
+Oa
+Wi
+MG
+MG
+hi
+fx
+Qu
+fr
+Wi
+Wi
+Cj
+zW
+mw
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+IK
+IK
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+VP
+VP
+VP
+DD
+tj
+Br
+bu
+bu
+mf
+hC
+El
+bO
+dn
+dn
+dn
+Ds
+Fr
+Fr
+Fr
+Fr
+Fr
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+zc
+in
+ed
+BO
+Pq
+Qx
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(40,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+km
+Rj
+Rj
+BI
+BI
+BI
+BI
+ag
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+rM
+aJ
+LD
+VZ
+rM
+Tu
+Wi
+Wi
+Wi
+ug
+Wi
+Wi
+Wi
+Wi
+ek
+Cj
+Sr
+mw
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+MV
+Un
+Iy
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+VP
+VP
+VP
+DD
+DD
+Br
+hn
+ho
+dn
+dn
+tN
+dn
+dn
+Nz
+dn
+hM
+Fr
+wz
+hV
+cj
+Fr
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+ab
+ng
+ng
+ng
+ng
+NH
+NH
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(41,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+km
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+rM
+Go
+vK
+ot
+AA
+Wi
+bt
+ft
+Be
+Cj
+oQ
+fw
+Wi
+fC
+Wi
+fN
+mw
+mw
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+EC
+LW
+FZ
+he
+FZ
+he
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+VP
+VP
+VP
+DD
+DD
+gY
+JL
+dn
+dn
+nV
+Br
+dn
+dn
+dn
+dn
+dn
+yP
+bY
+cb
+OJ
+Fr
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+NH
+NH
+NH
+NH
+NH
+NH
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(42,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+km
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+rM
+pX
+fc
+Eu
+rM
+Wi
+Wi
+ft
+ft
+Cj
+fw
+fw
+bt
+fC
+Wi
+fN
+mw
+mw
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+EC
+he
+sx
+he
+sx
+he
+Iy
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+VP
+VP
+VP
+DD
+DD
+gY
+JL
+dn
+dn
+dn
+Br
+dn
+dn
+dn
+dn
+nV
+Fr
+Tk
+cd
+cl
+Fr
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+NH
+NH
+NH
+NH
+NH
+NH
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(43,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+km
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+rM
+rM
+rM
+rM
+rM
+Oa
+Wi
+Wi
+Wi
+li
+Wi
+Wi
+Wi
+Wi
+Qj
+Cj
+aq
+aq
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+nm
+aa
+aa
+aa
+aa
+VP
+VP
+VP
+VP
+VP
+VP
+Br
+JL
+ho
+dn
+dn
+dn
+dn
+dn
+dn
+dn
+zB
+Fr
+Fr
+Fr
+Fr
+Fr
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+NH
+NH
+NH
+NH
+NH
+NH
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(44,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+Yz
+Yz
+xm
+Vd
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+km
+Ti
+Ti
+Ti
+km
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+rM
+aJ
+LD
+VZ
+rM
+Wi
+Wi
+Wi
+Wi
+hi
+bz
+aM
+fr
+Wi
+Wi
+Cj
+aq
+aq
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+VP
+VP
+VP
+VP
+VP
+Br
+vQ
+fo
+JL
+dn
+Nz
+dn
+dn
+dn
+dn
+dn
+Fr
+wz
+hV
+cj
+Fr
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+NH
+NH
+NH
+NH
+NH
+NH
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(45,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+sJ
+sJ
+xm
+vb
+MP
+MP
+MP
+Sg
+MP
+MP
+MP
+WH
+MP
+MP
+MP
+WH
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+rM
+Go
+vK
+ot
+AA
+Wi
+ug
+Wi
+Wi
+au
+Rk
+aN
+aw
+fE
+Wi
+Cj
+aq
+aq
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+VP
+VP
+VP
+VP
+VP
+Br
+XY
+RD
+jj
+dn
+dn
+tN
+dn
+dn
+dn
+dn
+yP
+Pt
+cb
+OJ
+Fr
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+NH
+NH
+NH
+NH
+NH
+NH
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(46,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+sJ
+sJ
+sJ
+sJ
+sJ
+sJ
+sJ
+Gv
+sJ
+sJ
+sJ
+Gv
+sJ
+sJ
+wC
+nP
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+rM
+pX
+fc
+Eu
+rM
+gg
+gg
+bN
+bN
+gg
+gg
+gg
+gg
+gg
+gg
+gg
+aq
+aq
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+VP
+VP
+VP
+VP
+Cb
+VP
+yF
+yF
+IF
+yF
+tk
+lV
+jP
+tk
+yF
+yF
+yF
+jP
+Tk
+cd
+cl
+Fr
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+NH
+NH
+NH
+NH
+NH
+NH
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+sN
+"}
+(47,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+sJ
+sJ
+sJ
+sJ
+sJ
+sJ
+sJ
+Gv
+sJ
+sJ
+sJ
+Gv
+sJ
+sJ
+wC
+hc
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+rM
+rM
+rM
+rM
+gg
+gg
+Qk
+Cq
+yE
+cr
+gg
+yE
+yE
+yE
+yE
+rM
+aq
+aq
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Cb
+Cb
+NW
+vr
+tk
+Li
+tk
+tk
+tk
+tk
+RC
+tk
+tk
+yF
+dG
+dG
+dG
+dG
+ab
+ab
+VP
+VP
+vE
+VP
+VP
+VP
+VP
+NH
+NH
+NH
+NH
+NH
+NH
+vY
+vY
+xt
+vY
+vY
+vY
+Dw
+vY
+vY
+vY
+Dw
+OK
+"}
+(48,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+sJ
+sJ
+sJ
+sJ
+sJ
+sJ
+sJ
+sJ
+sJ
+sJ
+sJ
+Gv
+sJ
+sJ
+wC
+hc
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+AX
+gg
+mi
+Kh
+yE
+cN
+gg
+yE
+yE
+yE
+yE
+rM
+aq
+aq
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Uh
+xw
+ci
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+Zc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+he
+Cb
+Cb
+xf
+gh
+tk
+zM
+tk
+Op
+Op
+tk
+wj
+tk
+tk
+Yy
+KU
+KU
+KU
+KU
+KU
+ab
+VP
+VP
+ei
+eo
+VP
+VP
+VP
+NH
+NH
+NH
+NH
+NH
+NH
+ia
+ia
+uX
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+"}
+(49,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+sJ
+sJ
+sJ
+sJ
+sJ
+sJ
+sJ
+sJ
+sJ
+sJ
+sJ
+sJ
+Gv
+sJ
+sJ
+sJ
+sJ
+Rj
+Rj
+Rj
+Rj
+Rj
+Rj
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+AX
+rM
+yE
+yE
+kY
+ZB
+Df
+yE
+yE
+yE
+yE
+rM
+aq
+aq
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Cb
+Cb
+Nb
+CC
+OX
+zM
+tk
+tk
+tk
+Jm
+wj
+OX
+tk
+wR
+KU
+KU
+KU
+KU
+KU
+ab
+VP
+VP
+VP
+VP
+VP
+VP
+VP
+NH
+NH
+NH
+NH
+NH
+NH
+ia
+ia
+ia
+ia
+ia
+ia
+ir
+ia
+ia
+ia
+ir
+ia
+"}
+(50,1,2) = {"
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+aa
+AX
+rM
+rM
+rM
+rM
+rM
+rM
+rM
+rM
+rM
+rM
+rM
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+pF
+pF
+yS
+yS
+pF
+pF
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+jP
+jP
+jP
+yF
+jP
+jP
+jP
+jP
+GT
+jP
+jP
+jP
+pF
+pF
+pF
+pF
+pF
+pF
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ee
+ee
+ee
+ee
+ee
+ee
+ee
+ee
+NH
+NH
+ee
+ee
+ee
+NH
+NH
+NH
+NH
+NH
 "}


### PR DESCRIPTION
Removes gun attachments from bases' vending machines(holo sight, grips, laser sight etc)
<img width="748" height="642" alt="image" src="https://github.com/user-attachments/assets/68cb5609-3390-4edc-b8e7-27749d60d11d" />
<img width="667" height="282" alt="image" src="https://github.com/user-attachments/assets/13b35855-0d63-4b3a-91c3-69cb0437cb3d" />
Reason is in the image above, and test
Idk what they did stat-wise for the weapons but...
