### PR TITLE
Golt changes and cargo changes

### DIFF
--- a/code/modules/placeholder/placeholder.dm
+++ b/code/modules/placeholder/placeholder.dm
@@ -461,7 +461,8 @@ GLOBAL_LIST_EMPTY(faction_dosh)
 
 		// general weapon stuff
 		list("name" = "Shotgun Pack", "price" = 100, "category" = "Brass.Co Top-Brass", "path" = /obj/structure/closet/crate/secure/weapon, "willcontain" = list(/obj/item/gun/projectile/shotgun/pump/shitty = 5)),
-		list("name" = "Pistol Pack", "price" = 100, "category" = "Brass.Co Top-Brass", "path" = /obj/structure/closet/crate/secure/weapon, "willcontain" = list(/obj/item/gun/projectile/golt = 2, /obj/item/gun/projectile/warfare = 3)),
+		list("name" = "Golt Pack", "price" = 100, "category" = "Brass.Co Top-Brass", "path" = /obj/structure/closet/crate/secure/weapon, "willcontain" = list(/obj/item/gun/projectile/golt = 2)),
+		list("name" = "Pistol Pack", "price" = 100, "category" = "Brass.Co Top-Brass", "path" = /obj/structure/closet/crate/secure/weapon, "willcontain" = list(/obj/item/gun/projectile/warfare = 3)),
 		list("name" = "Harbinger Pack", "price" = 100, "category" = "Brass.Co Top-Brass", "path" = /obj/structure/closet/crate/secure/weapon, "willcontain" = list(/obj/item/gun/projectile/automatic/mg08 = 2)),
 		list("name" = "Warmonger Pack", "price" = 100, "category" = "Brass.Co Top-Brass", "path" = /obj/structure/closet/crate/secure/weapon, "willcontain" = list(/obj/item/gun/projectile/automatic/m22/warmonger = 10)),
 		list("name" = "Shovel Pack", "price" = 50, "category" = "Brass.Co Top-Brass", "path" = /obj/structure/closet/crate/wooden, "willcontain" = list(/obj/item/shovel = 5)),
@@ -529,7 +530,8 @@ GLOBAL_LIST_EMPTY(faction_dosh)
 
 		// general weapon stuff
 		list("name" = "Shotgun Pack", "price" = 100, "category" = "Brass.Co Top-Brass", "path" = /obj/structure/closet/crate/wooden, "willcontain" = list(/obj/item/gun/projectile/shotgun/pump/shitty = 5)),
-		list("name" = "Pistol Pack", "price" = 100, "category" = "Brass.Co Top-Brass", "path" = /obj/structure/closet/crate/wooden, "willcontain" = list(/obj/item/gun/projectile/golt = 2, /obj/item/gun/projectile/warfare = 3)),
+		list("name" = "Golt Pack", "price" = 100, "category" = "Brass.Co Top-Brass", "path" = /obj/structure/closet/crate/secure/weapon, "willcontain" = list(/obj/item/gun/projectile/golt = 2)),
+		list("name" = "Pistol Pack", "price" = 100, "category" = "Brass.Co Top-Brass", "path" = /obj/structure/closet/crate/secure/weapon, "willcontain" = list(/obj/item/gun/projectile/warfare = 3)),
 		list("name" = "Harbinger Pack", "price" = 100, "category" = "Brass.Co Top-Brass", "path" = /obj/structure/closet/crate/wooden, "willcontain" = list(/obj/item/gun/projectile/automatic/mg08 = 2)),
 		list("name" = "Warmonger Pack", "price" = 100, "category" = "Brass.Co Top-Brass", "path" = /obj/structure/closet/crate/wooden, "willcontain" = list(/obj/item/gun/projectile/automatic/m22/warmonger = 10)),
 		list("name" = "Shovel Pack", "price" = 50, "category" = "Brass.Co Top-Brass", "path" = /obj/structure/closet/crate/wooden, "willcontain" = list(/obj/item/shovel = 5)),

--- a/code/modules/projectiles/guns/projectile/mattguns.dm
+++ b/code/modules/projectiles/guns/projectile/mattguns.dm
@@ -901,13 +901,14 @@
 	icon_state = "colt"
 	unloaded_icon = "colt-e"
 	item_state = "handgun"
-	fire_sound = "sound/weapons/guns/fire/pistol1.ogg"
+	fire_sound = "sound/weapons/guns/fire/revolver.ogg"
 	desc = "Potent handgun that fires an unwieldy and unusual caliber, denotated 'Wristfucker'."
 	magazine_type = /obj/item/ammo_magazine/a50
 	allowed_magazines = /obj/item/ammo_magazine/a50
 	caliber = ".50"
 	load_method = MAGAZINE
-	fire_delay = 5
+	fire_delay = 4
+	screen_shake = 3
 	condition = 75
 
 /obj/item/gun/projectile/shotgun/pump/boltaction/grenadelauncher


### PR DESCRIPTION
Separates the regular pistol and the Golt in Cargo.
You can get a Golt Pack, containing 2 Golts for 100
You can get a Pistol Pack, containing 3 regular pistols for 100
The ammo pack still contains both Golt and regular pistol mags.
Changes the Golt's fire sound to be more distinct from the other pistol
Adds a little more screen shake when firing the Golt
Lessens the fire delay when firing the Golt. It's still the double of the regular pistol