### PR TITLE
Gives red soldiers the Mk. 2 Glider

### DIFF
--- a/maps/coldfare/jobs/red/red_soldiers.dm
+++ b/maps/coldfare/jobs/red/red_soldiers.dm
@@ -289,6 +289,12 @@
 		backpack_contents = list(/obj/item/grenade/smokebomb = 1)
 		belt = /obj/item/storage/belt/armageddon
 
+	else if (prob(15))
+		suit_store = /obj/item/gun/projectile/shotgun/pump/boltaction/good
+		r_pocket =  /obj/item/ammo_box/rifle/modern
+		backpack_contents = initial(backpack_contents)
+		belt = null
+
 	else if(prob(25))
 		suit_store = /obj/item/gun/projectile/shotgun/pump/boltaction/shitty/leverchester
 		r_pocket = /obj/item/ammo_box/rifle


### PR DESCRIPTION
It seems like something or someone had removed the Mk. 2 glider spawn from red soldiers. Blue soldiers have them and the chances are equalized, there are no differences